### PR TITLE
Added a Global Time object with Sleep

### DIFF
--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -925,6 +925,36 @@ export class CommandLine {
   }
 }
 
+export class Time {
+  // Create a buffer for our number of sleep events
+  // To inspect how many events happened, one would then do load<i32>(neventsBuffer)
+  static _neventsBuffer = __alloc(4, 0);
+
+  static sleep(milliseconds: i32): void {
+    // Create our subscription to the clock
+    let clockSub = new clocksubscription();
+    clockSub.userdata = 1;
+    clockSub.identifier = 1;
+    clockSub.clock_id = clockid.REALTIME;
+    // Time is in nanoseconds (* 1000000 for milliseconds)
+    clockSub.timeout = milliseconds * 1000000;
+    clockSub.precision = 10000;
+    clockSub.type = eventtype.CLOCK;
+    // We want this to be relative, no flags / subclockflag
+
+    // Create our output event
+    let clockEvent = new event();
+
+    // Poll the subscription
+    poll_oneoff(
+      changetype<usize>(clockSub), // Pointer to the clock subscription
+      changetype<usize>(clockEvent), // Pointer to the clock event
+      1, // Number of events to wait for
+      changetype<usize>(Time._neventsBuffer) // Buffer where events should be stored.
+    );
+  }
+}
+
 class StringUtils {
   /**
    * Returns a native string from a zero-terminated C string

--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -928,16 +928,15 @@ export class CommandLine {
 export class Time {
   // Create a buffer for our number of sleep events
   // To inspect how many events happened, one would then do load<i32>(neventsBuffer)
-  static _neventsBuffer = __alloc(4, 0);
+  static _neventsBuffer: i32 = __alloc(4, 0);
 
-  static sleep(milliseconds: i32): void {
+  static sleep(nanoseconds: i32): void {
     // Create our subscription to the clock
     let clockSub = new clocksubscription();
     clockSub.userdata = 1;
     clockSub.identifier = 1;
     clockSub.clock_id = clockid.REALTIME;
-    // Time is in nanoseconds (* 1000000 for milliseconds)
-    clockSub.timeout = milliseconds * 1000000;
+    clockSub.timeout = nanoseconds;
     clockSub.precision = 10000;
     clockSub.type = eventtype.CLOCK;
     // We want this to be relative, no flags / subclockflag
@@ -952,6 +951,11 @@ export class Time {
       1, // Number of events to wait for
       changetype<usize>(Time._neventsBuffer) // Buffer where events should be stored.
     );
+  }
+
+  static sleepms(milliseconds: i32): void {
+    // sleep is in nanoseconds (* 1000000 for milliseconds)
+    Time.sleep(milliseconds * 1000000);
   }
 }
 


### PR DESCRIPTION
Hello!

Didn't open an issue for this, as it was simple, and I though we could discuss it here.

I am working on a WASI app that runs at 60 frames per second, and I needed to "wait" either by callback, or a sleep. And with the help of @dcodeIO I was able to get a sleep working like how I have in this PR. 

This adds a global time object, with a static sleep function, which could be useful for applications that run infinitely in a loop. And can let Wasm Runtimes to appropriately handle looping applications. 😄 

The reason why I chose the global object name "Time", is that Python also uses a [Time named import for their sleep](https://www.programiz.com/python-programming/time/sleep), and something like `setTimeout` is quite different from what this is actual doing (blocking while waiting for some time to pass), compared to what setTimeout does (Asynchronously call a callback after a specified amount of time). 👍 