### PR TITLE
Fix Date.now to return milliseconds instead of microseconds

### DIFF
--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -798,10 +798,10 @@ export class Date {
    */
   static now(): f64 {
     let time_ptr = changetype<usize>(new ArrayBuffer(8));
-    clock_time_get(clockid.REALTIME, 1000, time_ptr);
+    clock_time_get(clockid.REALTIME, 1000000, time_ptr);
     let unix_ts = load<u64>(time_ptr);
 
-    return (unix_ts as f64) / 1000.0;
+    return (unix_ts as f64) / 1000000.0;
   }
 }
 


### PR DESCRIPTION
Fixes #18 

clock_time_get returns the timestamp in nanoseconds (see timestamp definition in [WASI docs](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md)).
To convert to milliseconds the timestamp must be divided by 1000000 instead of 1000.