### PR TITLE
Fixed the memory leak for Time.sleep

### DIFF
--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -994,14 +994,11 @@ export class Time {
   static MILLISECOND: i32 = Time.NANOSECOND  * 1000000;
   static SECOND: i32      = Time.MILLISECOND * 1000;
 
+  // This uses some hardcoded values to fix issues from:
+  // https://github.com/AssemblyScript/assemblyscript/issues/1116
   static sleep(nanoseconds: i32): void {
-
-    let X = 0;
-    let Y = 3;
-    let Z = 0;
-
     // Create our subscription to the clock
-    let clockSub = changetype<subscription_clock>(__alloc(offsetof<subscription_clock>() + X, 0));
+    let clockSub = changetype<subscription_clock>(__alloc(offsetof<subscription_clock>(), 0));
     clockSub.userdata = 0;
     clockSub.clock_id = clockid.REALTIME;
     clockSub.timeout = nanoseconds;
@@ -1011,12 +1008,12 @@ export class Time {
     // We want this to be relative, no flags / subclockflag
 
     // Create our output event
-    let clockEvent = changetype<event>(__alloc(offsetof<event>() + Y, 0));
+    let clockEvent = changetype<event>(__alloc(offsetof<event>() + 3, 0));
 
     // Create a buffer for our number of sleep events
     // To inspect how many events happened, one would then do load<i32>(neventsBuffer)
     // @ts-ignore
-    let neventsBuffer = __alloc(4 + Z, 0);
+    let neventsBuffer = __alloc(4, 0);
 
     // Poll the subscription
     poll_oneoff(

--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -995,8 +995,13 @@ export class Time {
   static SECOND: i32      = Time.MILLISECOND * 1000;
 
   static sleep(nanoseconds: i32): void {
+
+    let X = 0;
+    let Y = 3;
+    let Z = 0;
+
     // Create our subscription to the clock
-    let clockSub = new subscription_clock();
+    let clockSub = changetype<subscription_clock>(__alloc(offsetof<subscription_clock>() + X, 0));
     clockSub.userdata = 0;
     clockSub.clock_id = clockid.REALTIME;
     clockSub.timeout = nanoseconds;
@@ -1006,20 +1011,24 @@ export class Time {
     // We want this to be relative, no flags / subclockflag
 
     // Create our output event
-    let clockEvent = new event();
+    let clockEvent = changetype<event>(__alloc(offsetof<event>() + Y, 0));
 
     // Create a buffer for our number of sleep events
     // To inspect how many events happened, one would then do load<i32>(neventsBuffer)
     // @ts-ignore
-    let neventsBuffer = changetype<ArrayBufferView>(mem64).dataStart;
+    let neventsBuffer = __alloc(4 + Z, 0);
 
     // Poll the subscription
     poll_oneoff(
       changetype<usize>(clockSub), // Pointer to the clock subscription
       changetype<usize>(clockEvent), // Pointer to the clock event
       1, // Number of events to wait for
-      neventsBuffer // Buffer where events should be stored.
+      changetype<usize>(neventsBuffer) // Buffer where events should be stored.
     );
+
+    __free(neventsBuffer);
+    __free(changetype<usize>(clockEvent));
+    __free(changetype<usize>(clockSub));
   }
 }
 


### PR DESCRIPTION
This frees the allocated memory by doing all the clock subscriptions in `Time.sleep`. 

This was prompted by: https://github.com/AssemblyScript/assemblyscript/issues/1116 and does the appropriate fix for the current version of AssemblyScript :smile: 

**Old Behavior When trying to free memory**

![Screenshot from 2020-04-07 11-58-05](https://user-images.githubusercontent.com/1448289/78708876-a5943500-78c7-11ea-8d2e-8c5da1bc100c.png)

**Fixed Behavior (This PR)**

![Screenshot from 2020-04-07 11-57-51](https://user-images.githubusercontent.com/1448289/78708894-acbb4300-78c7-11ea-8416-bdf6a6cc76f2.png)
