### PR TITLE
Revert fromCString to avoid allocation errors

### DIFF
--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -1021,7 +1021,11 @@ class StringUtils {
    */
   @inline
   static fromCString(cstring: usize): string {
-    return String.UTF8.decodeUnsafe(cstring, i32.MAX_VALUE, true);
+    let size = 0;
+    while (load<u8>(cstring + size) !== 0) {
+      size++;
+    }
+    return String.UTF8.decodeUnsafe(cstring, size);
   }
 }
 


### PR DESCRIPTION
closes #53

This commit reverts the implementation of `fromCString` to the one
before revision 22b52301479b9a3130ca796542d6c99aa4b63a30 in order to
avoid allocation errors when getting environment variables and command
line arguments.

The underlying issue with its implementation seems to be related to
passing the maximum integer value instead of the actual size, resulting
in an allocation overflow at runtime.

Another potential solution for this could be using the safe mechanisms
provided by AssemblyScript (`changetype` and `decode`, but there seem
to be some intermittent GC-related issues when using them, and this
requires some more investigation).

Signed-off-by: Radu M <root@radu.sh>
Co-authored-by: Matt Butcher <matt.butcher@microsoft.com>