### PR TITLE
Created a README and API Reference Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 build
 node_modules
+temp-docs

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <!--- Short Description-->
 
-A high-level AssemblyScript layer for the WebAssembly System Interface (WASI).
+A high-level AssemblyScript layer for the WebAssembly System Interface (WASI). 🧩
 
-[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules. AssemblyScript exposes the low-level WASI standard set of system calls. `as-wasi` builds a higher level API on top of the AssemblyScript WASI interface, at a similar level to the [Node API](https://nodejs.org/docs/latest/api/).
+[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules. AssemblyScript exposes the low-level WASI standard set of system calls. `as-wasi` builds a higher level API on top of the AssemblyScript WASI interface, at a similar level to the [Node API](https://nodejs.org/docs/latest/api/). 🚀
 
 ## Installation
 
@@ -36,9 +36,19 @@ let home = env.get("HOME")!;
 Console.log(home);
 ```
 
+Here are some exported classes that are commonly used:
+
+* `FileSystem` - Reading and Writing the user's fileystem. 📁
+* `Console` - General logging to stdout and stderr. 🖥️
+* `Environ` - Accessing environment variables, command flags, etc... 🌐
+* `Date` - Getting the current system time. 📅
+* `Random` - Accessing random numbers. 🤔
+* `Time` - Allow sleeping and waiting for events to occur. ⏰
+* And More! See the Reference API in the next section for the full API.
+
 ## Reference API Docs
 
-Reference API documentation can be found in [REFERENCE_API_DOCS](./REFERENCE_API_DOCS.md).
+Reference API documentation can be found in [REFERENCE_API_DOCS](./REFERENCE_API_DOCS.md). Documentation is generated using [typedoc](https://typedoc.org/).
 
 ## Projects using as-wasi
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,60 @@
-# An AssemblyScript layer for the WebAssembly System Interface (WASI)
+# as-wasi
 
-[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules.
+<!--- Badges -->
 
-`as-wasi` is an effort to expose the WASI standard set of system calls to AssemblyScript.
+![npm version](https://img.shields.io/npm/v/as-wasi.svg)
+![npm downloads per month](https://img.shields.io/npm/dm/as-wasi.svg)
+![GitHub License](https://img.shields.io/github/license/torch2424/as-wasi.svg)
 
-## Usage
+<!--- Short Description-->
+
+A high-level AssemblyScript layer for the WebAssembly System Interface (WASI).
+
+[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules. AssemblyScript exposes the low-level WASI standard set of system calls. `as-wasi` builds a higher level API on top of the AssemblyScript WASI interface, at a similar level to the [Node API](https://nodejs.org/docs/latest/api/).
+
+## Installation
+
+You can install `as-wasi` in your project by running the following:
+
+`npm install --save as-bind`
+
+## Quick Start
 
 Example usage of the `Console` and `Environ` classes:
 
 ```typescript
-import { Console, Environ } from "../node_modules/as-wasi/assembly";
+// Import from the installed as-wasi package
+import { Console, Environ } from "as-wasi";
 
+// Create an envrion instance
 let env = new Environ();
+
+// Get the HOME Environment variable
 let home = env.get("HOME")!;
+
+// Log the HOME string to stdout
 Console.log(home);
 ```
+
+## Reference API Docs
+
+Reference API documentation can be found in [REFERENCE_API_DOCS](./REFERENCE_API_DOCS.md).
+
+## Projects using as-wasi
+
+* [wasmboy](https://github.com/torch2424/wasmboy) - Game Boy / Game Boy Color Emulator Library, 🎮written for WebAssembly using AssemblyScript. 🚀
+* [wasmerio/io-devices-lib](https://github.com/wasmerio/io-devices-lib) - Library for interacting with the Wasmer Experimental IO Devices API. Uses WASI for outputting graphics in a framebuffer, and handles mouse/keyboard input.
+* [wasm-by-example](https://github.com/torch2424/wasm-by-example) - Wasm By Example is a website with a set of hands-on introduction examples and tutorials for WebAssembly (Wasm). Wasm By Example features `as-wasi` by default for the AssemblyScript WASI examples.
+* [wasm-matrix](https://github.com/torch2424/wasm-matrix) - A Matrix effect in your terminal using AssemblyScript 🚀 and WASI 🧩 . THhise project is a bit older, and uses an older version of `as-wasi`, but still creates a cool effect!
+
+_If you're project is using as-wasi, and you would like to be featured here. Please open a README with links to your project, and if appropriate, explaining how as-wasi is being used._ 😊
+
+## Contributing
+
+Contributions are definitely welcome! Feel free to open a PR for small fixes such as typos and things. Larger fixes, or new features should start out as an issue for discussion, in which then a PR should be made. 🥳
+
+This project will also adhere to the [AssemblyScript Code of Conduct](https://github.com/AssemblyScript/assemblyscript/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+[MIT](https://oss.ninja/mit/jesdict1). 📝

--- a/REFERENCE_API_DOCS.md
+++ b/REFERENCE_API_DOCS.md
@@ -3,169 +3,152 @@
 
 
 - [as-wasi](#as-wasi)
-- [as-wasi](#as-wasi-1)
-  - [Installation](#installation)
-  - [Quick Start](#quick-start)
-  - [Reference API Docs](#reference-api-docs)
-  - [Projects using as-wasi](#projects-using-as-wasi)
-  - [Contributing](#contributing)
-  - [License](#license)
-- [Classes](#classes)
+  - [Index](#index)
+    - [Classes](#classes)
+    - [Type aliases](#type-aliases)
+    - [Functions](#functions)
+  - [Type aliases](#type-aliases-1)
+    - [aisize](#aisize)
+  - [Functions](#functions-1)
+    - [wasi_abort](#wasi_abort)
+- [Classes](#classes-1)
   - [Class: CommandLine](#class-commandline)
     - [Hierarchy](#hierarchy)
-    - [Index](#index)
+    - [Index](#index-1)
     - [Constructors](#constructors)
     - [Properties](#properties)
     - [Methods](#methods)
   - [Class: Console](#class-console)
     - [Hierarchy](#hierarchy-1)
-    - [Index](#index-1)
+    - [Index](#index-2)
     - [Methods](#methods-1)
   - [Class: Date](#class-date)
     - [Hierarchy](#hierarchy-2)
-    - [Index](#index-2)
+    - [Index](#index-3)
     - [Methods](#methods-2)
   - [Class: Descriptor](#class-descriptor)
     - [Hierarchy](#hierarchy-3)
-    - [Index](#index-3)
+    - [Index](#index-4)
     - [Constructors](#constructors-1)
     - [Accessors](#accessors)
     - [Methods](#methods-3)
   - [Class: Environ](#class-environ)
     - [Hierarchy](#hierarchy-4)
-    - [Index](#index-4)
+    - [Index](#index-5)
     - [Constructors](#constructors-2)
     - [Properties](#properties-1)
     - [Methods](#methods-4)
   - [Class: EnvironEntry](#class-environentry)
     - [Hierarchy](#hierarchy-5)
-    - [Index](#index-5)
+    - [Index](#index-6)
     - [Constructors](#constructors-3)
     - [Properties](#properties-2)
   - [Class: FileStat](#class-filestat)
     - [Hierarchy](#hierarchy-6)
-    - [Index](#index-6)
+    - [Index](#index-7)
     - [Constructors](#constructors-4)
     - [Properties](#properties-3)
   - [Class: FileSystem](#class-filesystem)
     - [Hierarchy](#hierarchy-7)
-    - [Index](#index-7)
+    - [Index](#index-8)
     - [Methods](#methods-5)
   - [Class: Performance](#class-performance)
     - [Hierarchy](#hierarchy-8)
-    - [Index](#index-8)
+    - [Index](#index-9)
     - [Methods](#methods-6)
   - [Class: Process](#class-process)
     - [Hierarchy](#hierarchy-9)
-    - [Index](#index-9)
+    - [Index](#index-10)
     - [Methods](#methods-7)
   - [Class: Random](#class-random)
     - [Hierarchy](#hierarchy-10)
-    - [Index](#index-10)
+    - [Index](#index-11)
     - [Methods](#methods-8)
   - [Class: StringUtils](#class-stringutils)
     - [Hierarchy](#hierarchy-11)
-    - [Index](#index-11)
+    - [Index](#index-12)
     - [Methods](#methods-9)
   - [Class: Time](#class-time)
     - [Hierarchy](#hierarchy-12)
-    - [Index](#index-12)
+    - [Index](#index-13)
     - [Properties](#properties-4)
     - [Methods](#methods-10)
   - [Class: WASIError](#class-wasierror)
     - [Hierarchy](#hierarchy-13)
-    - [Index](#index-13)
+    - [Index](#index-14)
     - [Constructors](#constructors-5)
     - [Properties](#properties-5)
     - [Methods](#methods-11)
-- [as-wasi](#as-wasi-2)
-  - [Index](#index-14)
-    - [Modules](#modules)
-- [Modules](#modules-1)
-  - [Module: "assembly/as-wasi"](#module-assemblyas-wasi)
-    - [Index](#index-15)
-    - [Type aliases](#type-aliases)
-    - [Functions](#functions)
-  - [Module: "assembly/index"](#module-assemblyindex)
-    - [Index](#index-16)
-    - [References](#references)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 <a name="readmemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd)
+[as-wasi](#readmemd)
 
 # as-wasi
 
-# as-wasi
+## Index
 
-<!--- Badges -->
+### Classes
 
-![npm version](https://img.shields.io/npm/v/as-wasi.svg)
-![npm downloads per month](https://img.shields.io/npm/dm/as-wasi.svg)
-![GitHub License](https://img.shields.io/github/license/torch2424/as-wasi.svg)
+* [CommandLine](#classescommandlinemd)
+* [Console](#classesconsolemd)
+* [Date](#classesdatemd)
+* [Descriptor](#classesdescriptormd)
+* [Environ](#classesenvironmd)
+* [EnvironEntry](#classesenvironentrymd)
+* [FileStat](#classesfilestatmd)
+* [FileSystem](#classesfilesystemmd)
+* [Performance](#classesperformancemd)
+* [Process](#classesprocessmd)
+* [Random](#classesrandommd)
+* [StringUtils](#classesstringutilsmd)
+* [Time](#classestimemd)
+* [WASIError](#classeswasierrormd)
 
-<!--- Short Description-->
+### Type aliases
 
-A high-level AssemblyScript layer for the WebAssembly System Interface (WASI).
+* [aisize](#aisize)
 
-[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules. AssemblyScript exposes the low-level WASI standard set of system calls. `as-wasi` builds a higher level API on top of the AssemblyScript WASI interface, at a similar level to the [Node API](https://nodejs.org/docs/latest/api/).
+### Functions
 
-## Installation
+* [wasi_abort](#wasi_abort)
 
-You can install `as-wasi` in your project by running the following:
+## Type aliases
 
-`npm install --save as-bind`
+###  aisize
 
-## Quick Start
+Ƭ **aisize**: *i32*
 
-Example usage of the `Console` and `Environ` classes:
+*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L55)*
 
-```typescript
-// Import from the installed as-wasi package
-import { Console, Environ } from "as-wasi";
+## Functions
 
-// Create an envrion instance
-let env = new Environ();
+###  wasi_abort
 
-// Get the HOME Environment variable
-let home = env.get("HOME")!;
+▸ **wasi_abort**(`message`: string, `fileName`: string, `lineNumber`: u32, `columnNumber`: u32): *void*
 
-// Log the HOME string to stdout
-Console.log(home);
-```
+*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L1034)*
 
-## Reference API Docs
+**Parameters:**
 
-Reference API documentation can be found in [REFERENCE_API_DOCS](./REFERENCE_API_DOCS.md).
+Name | Type | Default |
+------ | ------ | ------ |
+`message` | string | "" |
+`fileName` | string | "" |
+`lineNumber` | u32 | 0 |
+`columnNumber` | u32 | 0 |
 
-## Projects using as-wasi
-
-* [wasmboy](https://github.com/torch2424/wasmboy) - Game Boy / Game Boy Color Emulator Library, 🎮written for WebAssembly using AssemblyScript. 🚀
-* [wasmerio/io-devices-lib](https://github.com/wasmerio/io-devices-lib) - Library for interacting with the Wasmer Experimental IO Devices API. Uses WASI for outputting graphics in a framebuffer, and handles mouse/keyboard input.
-* [wasm-by-example](https://github.com/torch2424/wasm-by-example) - Wasm By Example is a website with a set of hands-on introduction examples and tutorials for WebAssembly (Wasm). Wasm By Example features `as-wasi` by default for the AssemblyScript WASI examples.
-* [wasm-matrix](https://github.com/torch2424/wasm-matrix) - A Matrix effect in your terminal using AssemblyScript 🚀 and WASI 🧩 . THhise project is a bit older, and uses an older version of `as-wasi`, but still creates a cool effect!
-
-_If you're project is using as-wasi, and you would like to be featured here. Please open a README with links to your project, and if appropriate, explaining how as-wasi is being used._ 😊
-
-## Contributing
-
-Contributions are definitely welcome! Feel free to open a PR for small fixes such as typos and things. Larger fixes, or new features should start out as an issue for discussion, in which then a PR should be made. 🥳
-
-This project will also adhere to the [AssemblyScript Code of Conduct](https://github.com/AssemblyScript/assemblyscript/blob/master/CODE_OF_CONDUCT.md).
-
-## License
-
-[MIT](https://oss.ninja/mit/jesdict1). 📝
+**Returns:** *void*
 
 # Classes
 
 
-<a name="classes_assembly_as_wasi_commandlinemd"></a>
+<a name="classescommandlinemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [CommandLine](#classes_assembly_as_wasi_commandlinemd)
+[as-wasi](#readmemd) › [CommandLine](#classescommandlinemd)
 
 ## Class: CommandLine
 
@@ -192,11 +175,11 @@ This project will also adhere to the [AssemblyScript Code of Conduct](https://gi
 
 ####  constructor
 
-\+ **new CommandLine**(): *[CommandLine](#classes_assembly_as_wasi_commandlinemd)*
+\+ **new CommandLine**(): *[CommandLine](#classescommandlinemd)*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L929)*
 
-**Returns:** *[CommandLine](#classes_assembly_as_wasi_commandlinemd)*
+**Returns:** *[CommandLine](#classescommandlinemd)*
 
 ### Properties
 
@@ -204,7 +187,7 @@ This project will also adhere to the [AssemblyScript Code of Conduct](https://gi
 
 • **args**: *string[]*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L929)*
 
 ### Methods
 
@@ -212,7 +195,7 @@ This project will also adhere to the [AssemblyScript Code of Conduct](https://gi
 
 ▸ **all**(): *Array‹string›*
 
-*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L958)*
+*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L958)*
 
 Return all the command-line arguments
 
@@ -224,7 +207,7 @@ ___
 
 ▸ **get**(`i`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L966)*
+*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L966)*
 
 Return the i-th command-ine argument
 
@@ -237,9 +220,9 @@ Name | Type | Description |
 **Returns:** *string | null*
 
 
-<a name="classes_assembly_as_wasi_consolemd"></a>
+<a name="classesconsolemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Console](#classes_assembly_as_wasi_consolemd)
+[as-wasi](#readmemd) › [Console](#classesconsolemd)
 
 ## Class: Console
 
@@ -262,7 +245,7 @@ Name | Type | Description |
 
 ▸ **error**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L804)*
+*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L804)*
 
 Write an error to the console
 
@@ -281,7 +264,7 @@ ___
 
 ▸ **log**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L795)*
+*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L795)*
 
 Alias for `Console.write()`
 
@@ -299,7 +282,7 @@ ___
 
 ▸ **readAll**(): *string | null*
 
-*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L788)*
+*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L788)*
 
 Read an UTF8 string from the console, convert it to a native string
 
@@ -311,7 +294,7 @@ ___
 
 ▸ **write**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L781)*
+*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L781)*
 
 Write a string to the console
 
@@ -325,9 +308,9 @@ Name | Type | Default | Description |
 **Returns:** *void*
 
 
-<a name="classes_assembly_as_wasi_datemd"></a>
+<a name="classesdatemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Date](#classes_assembly_as_wasi_datemd)
+[as-wasi](#readmemd) › [Date](#classesdatemd)
 
 ## Class: Date
 
@@ -347,16 +330,16 @@ Name | Type | Default | Description |
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L842)*
+*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L842)*
 
 Return the current timestamp, as a number of milliseconds since the epoch
 
 **Returns:** *f64*
 
 
-<a name="classes_assembly_as_wasi_descriptormd"></a>
+<a name="classesdescriptormd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Descriptor](#classes_assembly_as_wasi_descriptormd)
+[as-wasi](#readmemd) › [Descriptor](#classesdescriptormd)
 
 ## Class: Descriptor
 
@@ -409,9 +392,9 @@ A descriptor, that doesn't necessarily have to represent a file
 
 ####  constructor
 
-\+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+\+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L109)*
 
 Build a new descriptor from a raw WASI file descriptor
 
@@ -421,7 +404,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `rawfd` | fd | a raw file descriptor  |
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+**Returns:** *[Descriptor](#classesdescriptormd)*
 
 ### Accessors
 
@@ -429,7 +412,7 @@ Name | Type | Description |
 
 • **get rawfd**(): *fd*
 
-*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L119)*
+*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L119)*
 
 **Returns:** *fd*
 
@@ -437,49 +420,49 @@ ___
 
 #### `Static` Invalid
 
-• **get Invalid**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+• **get Invalid**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L94)*
+*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L94)*
 
 An invalid file descriptor, that can represent an error
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+**Returns:** *[Descriptor](#classesdescriptormd)*
 
 ___
 
 #### `Static` Stderr
 
-• **get Stderr**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+• **get Stderr**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L109)*
 
 The standard error
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+**Returns:** *[Descriptor](#classesdescriptormd)*
 
 ___
 
 #### `Static` Stdin
 
-• **get Stdin**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+• **get Stdin**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L99)*
+*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L99)*
 
 The standard input
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+**Returns:** *[Descriptor](#classesdescriptormd)*
 
 ___
 
 #### `Static` Stdout
 
-• **get Stdout**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+• **get Stdout**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L104)*
+*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L104)*
 
 The standard output
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
+**Returns:** *[Descriptor](#classesdescriptormd)*
 
 ### Methods
 
@@ -487,7 +470,7 @@ The standard output
 
 ▸ **advise**(`offset`: u64, `len`: u64, `advice`: advice): *bool*
 
-*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L130)*
+*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L130)*
 
 Hint at how the data accessible via the descriptor will be used
 
@@ -515,7 +498,7 @@ ___
 
 ▸ **allocate**(`offset`: u64, `len`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L140)*
+*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L140)*
 
 Preallocate data
 
@@ -536,7 +519,7 @@ ___
 
 ▸ **close**(): *void*
 
-*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L283)*
+*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L283)*
 
 Close a file descriptor
 
@@ -548,7 +531,7 @@ ___
 
 ▸ **dirName**(): *string*
 
-*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L261)*
+*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L261)*
 
 Return the directory associated to that descriptor
 
@@ -560,7 +543,7 @@ ___
 
 ▸ **fatime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L207)*
+*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L207)*
 
 Update the access time
 
@@ -582,7 +565,7 @@ ___
 
 ▸ **fdatasync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L148)*
+*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L148)*
 
 Wait for the data to be written
 
@@ -596,7 +579,7 @@ ___
 
 ▸ **fileType**(): *filetype*
 
-*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L163)*
+*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L163)*
 
 Return the file type
 
@@ -608,7 +591,7 @@ ___
 
 ▸ **fmtime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L219)*
+*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L219)*
 
 Update the modification time
 
@@ -630,7 +613,7 @@ ___
 
 ▸ **fsync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L156)*
+*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L156)*
 
 Wait for the data and metadata to be written
 
@@ -644,7 +627,7 @@ ___
 
 ▸ **ftruncate**(`size`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L198)*
+*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L198)*
 
 Change the size of a file
 
@@ -664,7 +647,7 @@ ___
 
 ▸ **futimes**(`atime`: f64, `mtime`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L232)*
+*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L232)*
 
 Update both the access and the modification times
 
@@ -689,7 +672,7 @@ ___
 
 ▸ **read**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L348)*
+*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L348)*
 
 Read data from a file descriptor
 
@@ -708,7 +691,7 @@ ___
 
 ▸ **readAll**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L373)*
+*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L373)*
 
 Read from a file descriptor until the end of the stream
 
@@ -727,7 +710,7 @@ ___
 
 ▸ **readString**(`chunk_size`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L404)*
+*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L404)*
 
 Read an UTF8 string from a file descriptor, convert it to a native string
 
@@ -745,7 +728,7 @@ ___
 
 ▸ **seek**(`off`: u64, `w`: whence): *bool*
 
-*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L418)*
+*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L418)*
 
 Seek into a stream
 
@@ -768,7 +751,7 @@ ___
 
 ▸ **setFlags**(`flags`: fdflags): *bool*
 
-*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L177)*
+*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L177)*
 
 Set WASI flags for that descriptor
 
@@ -788,13 +771,13 @@ ___
 
 ####  stat
 
-▸ **stat**(): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+▸ **stat**(): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L185)*
+*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L185)*
 
 Retrieve information about a descriptor
 
-**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+**Returns:** *[FileStat](#classesfilestatmd)*
 
 a `FileStat` object`
 
@@ -804,7 +787,7 @@ ___
 
 ▸ **tell**(): *u64*
 
-*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L429)*
+*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L429)*
 
 Return the current offset in the stream
 
@@ -818,7 +801,7 @@ ___
 
 ▸ **touch**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L247)*
+*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L247)*
 
 Update the timestamp of the object represented by the descriptor
 
@@ -832,7 +815,7 @@ ___
 
 ▸ **write**(`data`: u8[]): *void*
 
-*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L291)*
+*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L291)*
 
 Write data to a file descriptor
 
@@ -850,7 +833,7 @@ ___
 
 ▸ **writeString**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L309)*
+*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L309)*
 
 Write a string to a file descriptor, after encoding it to UTF8
 
@@ -869,7 +852,7 @@ ___
 
 ▸ **writeStringLn**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L328)*
+*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L328)*
 
 Write a string to a file descriptor, after encoding it to UTF8, with a newline
 
@@ -882,9 +865,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classes_assembly_as_wasi_environmd"></a>
+<a name="classesenvironmd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Environ](#classes_assembly_as_wasi_environmd)
+[as-wasi](#readmemd) › [Environ](#classesenvironmd)
 
 ## Class: Environ
 
@@ -911,31 +894,31 @@ Name | Type | Description |
 
 ####  constructor
 
-\+ **new Environ**(): *[Environ](#classes_assembly_as_wasi_environmd)*
+\+ **new Environ**(): *[Environ](#classesenvironmd)*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L877)*
 
-**Returns:** *[Environ](#classes_assembly_as_wasi_environmd)*
+**Returns:** *[Environ](#classesenvironmd)*
 
 ### Properties
 
 ####  env
 
-• **env**: *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
+• **env**: *Array‹[EnvironEntry](#classesenvironentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L877)*
 
 ### Methods
 
 ####  all
 
-▸ **all**(): *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
+▸ **all**(): *Array‹[EnvironEntry](#classesenvironentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L908)*
+*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L908)*
 
  Return all environment variables
 
-**Returns:** *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
+**Returns:** *Array‹[EnvironEntry](#classesenvironentrymd)›*
 
 ___
 
@@ -943,7 +926,7 @@ ___
 
 ▸ **get**(`key`: string): *string | null*
 
-*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L916)*
+*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L916)*
 
 Return the value for an environment variable
 
@@ -956,9 +939,9 @@ Name | Type | Description |
 **Returns:** *string | null*
 
 
-<a name="classes_assembly_as_wasi_environentrymd"></a>
+<a name="classesenvironentrymd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [EnvironEntry](#classes_assembly_as_wasi_environentrymd)
+[as-wasi](#readmemd) › [EnvironEntry](#classesenvironentrymd)
 
 ## Class: EnvironEntry
 
@@ -981,9 +964,9 @@ Name | Type | Description |
 
 ####  constructor
 
-\+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classes_assembly_as_wasi_environentrymd)*
+\+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classesenvironentrymd)*
 
-*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L872)*
+*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L872)*
 
 **Parameters:**
 
@@ -992,7 +975,7 @@ Name | Type |
 `key` | string |
 `value` | string |
 
-**Returns:** *[EnvironEntry](#classes_assembly_as_wasi_environentrymd)*
+**Returns:** *[EnvironEntry](#classesenvironentrymd)*
 
 ### Properties
 
@@ -1000,7 +983,7 @@ Name | Type |
 
 • **key**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L873)*
 
 ___
 
@@ -1008,12 +991,12 @@ ___
 
 • **value**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L873)*
 
 
-<a name="classes_assembly_as_wasi_filestatmd"></a>
+<a name="classesfilestatmd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [FileStat](#classes_assembly_as_wasi_filestatmd)
+[as-wasi](#readmemd) › [FileStat](#classesfilestatmd)
 
 ## Class: FileStat
 
@@ -1041,9 +1024,9 @@ Portable information about a file
 
 ####  constructor
 
-\+ **new FileStat**(`st_buf`: usize): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+\+ **new FileStat**(`st_buf`: usize): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L75)*
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L75)*
 
 **Parameters:**
 
@@ -1051,7 +1034,7 @@ Name | Type |
 ------ | ------ |
 `st_buf` | usize |
 
-**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+**Returns:** *[FileStat](#classesfilestatmd)*
 
 ### Properties
 
@@ -1059,7 +1042,7 @@ Name | Type |
 
 • **access_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:73](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L73)*
+*Defined in [assembly/as-wasi.ts:73](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L73)*
 
 ___
 
@@ -1067,7 +1050,7 @@ ___
 
 • **creation_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L75)*
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L75)*
 
 ___
 
@@ -1075,7 +1058,7 @@ ___
 
 • **file_size**: *filesize*
 
-*Defined in [assembly/as-wasi.ts:72](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L72)*
+*Defined in [assembly/as-wasi.ts:72](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L72)*
 
 ___
 
@@ -1083,7 +1066,7 @@ ___
 
 • **file_type**: *filetype*
 
-*Defined in [assembly/as-wasi.ts:71](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L71)*
+*Defined in [assembly/as-wasi.ts:71](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L71)*
 
 ___
 
@@ -1091,12 +1074,12 @@ ___
 
 • **modification_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:74](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L74)*
+*Defined in [assembly/as-wasi.ts:74](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L74)*
 
 
-<a name="classes_assembly_as_wasi_filesystemmd"></a>
+<a name="classesfilesystemmd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [FileSystem](#classes_assembly_as_wasi_filesystemmd)
+[as-wasi](#readmemd) › [FileSystem](#classesfilesystemmd)
 
 ## Class: FileSystem
 
@@ -1129,7 +1112,7 @@ A class to access a filesystem
 
 ▸ **dirfdForPath**(`path`: string): *fd*
 
-*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L769)*
+*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L769)*
 
 **Parameters:**
 
@@ -1145,7 +1128,7 @@ ___
 
 ▸ **exists**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L533)*
+*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L533)*
 
 Check if a file exists at a given path
 
@@ -1167,7 +1150,7 @@ ___
 
 ▸ **link**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L556)*
+*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L556)*
 
 Create a hard link
 
@@ -1190,9 +1173,9 @@ ___
 
 #### `Static` lstat
 
-▸ **lstat**(`path`: string): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+▸ **lstat**(`path`: string): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L672)*
+*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L672)*
 
 Retrieve information about a file or a symbolic link
 
@@ -1204,7 +1187,7 @@ Name | Type |
 ------ | ------ |
 `path` | string |
 
-**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+**Returns:** *[FileStat](#classesfilestatmd)*
 
 a `FileStat` object
 
@@ -1214,7 +1197,7 @@ ___
 
 ▸ **mkdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L516)*
+*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L516)*
 
 Create a new directory
 
@@ -1234,9 +1217,9 @@ ___
 
 #### `Static` open
 
-▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classes_assembly_as_wasi_descriptormd) | null*
+▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classesdescriptormd) | null*
 
-*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L449)*
+*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L449)*
 
 Open a path
 
@@ -1251,7 +1234,7 @@ Name | Type | Default |
 `path` | string | - |
 `flags` | string | "r" |
 
-**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd) | null*
+**Returns:** *[Descriptor](#classesdescriptormd) | null*
 
 a descriptor
 
@@ -1261,7 +1244,7 @@ ___
 
 ▸ **readdir**(`path`: string): *Array‹string› | null*
 
-*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L726)*
+*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L726)*
 
 Get the content of a directory
 
@@ -1281,7 +1264,7 @@ ___
 
 ▸ **rename**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L698)*
+*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L698)*
 
 Rename a file
 
@@ -1306,7 +1289,7 @@ ___
 
 ▸ **rmdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L630)*
+*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L630)*
 
 Remove a directory
 
@@ -1326,9 +1309,9 @@ ___
 
 #### `Static` stat
 
-▸ **stat**(`path`: string): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+▸ **stat**(`path`: string): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L647)*
+*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L647)*
 
 Retrieve information about a file
 
@@ -1340,7 +1323,7 @@ Name | Type |
 ------ | ------ |
 `path` | string |
 
-**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+**Returns:** *[FileStat](#classesfilestatmd)*
 
 a `FileStat` object
 
@@ -1350,7 +1333,7 @@ ___
 
 ▸ **symlink**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L587)*
+*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L587)*
 
 Create a symbolic link
 
@@ -1375,7 +1358,7 @@ ___
 
 ▸ **unlink**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L613)*
+*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L613)*
 
 Unlink a file
 
@@ -1392,9 +1375,9 @@ Name | Type |
 `true` on success, `false` on failure
 
 
-<a name="classes_assembly_as_wasi_performancemd"></a>
+<a name="classesperformancemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Performance](#classes_assembly_as_wasi_performancemd)
+[as-wasi](#readmemd) › [Performance](#classesperformancemd)
 
 ## Class: Performance
 
@@ -1414,14 +1397,14 @@ Name | Type |
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L852)*
+*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L852)*
 
 **Returns:** *f64*
 
 
-<a name="classes_assembly_as_wasi_processmd"></a>
+<a name="classesprocessmd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Process](#classes_assembly_as_wasi_processmd)
+[as-wasi](#readmemd) › [Process](#classesprocessmd)
 
 ## Class: Process
 
@@ -1441,7 +1424,7 @@ Name | Type |
 
 ▸ **exit**(`status`: u32): *void*
 
-*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L867)*
+*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L867)*
 
 Cleanly terminate the current process
 
@@ -1454,9 +1437,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classes_assembly_as_wasi_randommd"></a>
+<a name="classesrandommd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Random](#classes_assembly_as_wasi_randommd)
+[as-wasi](#readmemd) › [Random](#classesrandommd)
 
 ## Class: Random
 
@@ -1477,7 +1460,7 @@ Name | Type | Description |
 
 ▸ **randomBytes**(`len`: usize): *Uint8Array*
 
-*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L831)*
+*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L831)*
 
 Return an array of random bytes
 
@@ -1495,7 +1478,7 @@ ___
 
 ▸ **randomFill**(`buffer`: ArrayBuffer): *void*
 
-*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L814)*
+*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L814)*
 
 Fill a buffer with random data
 
@@ -1508,9 +1491,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classes_assembly_as_wasi_stringutilsmd"></a>
+<a name="classesstringutilsmd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [StringUtils](#classes_assembly_as_wasi_stringutilsmd)
+[as-wasi](#readmemd) › [StringUtils](#classesstringutilsmd)
 
 ## Class: StringUtils
 
@@ -1530,7 +1513,7 @@ Name | Type | Description |
 
 ▸ **fromCString**(`cstring`: usize): *string*
 
-*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L1023)*
+*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L1023)*
 
 Returns a native string from a zero-terminated C string
 
@@ -1545,9 +1528,9 @@ Name | Type |
 native string
 
 
-<a name="classes_assembly_as_wasi_timemd"></a>
+<a name="classestimemd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Time](#classes_assembly_as_wasi_timemd)
+[as-wasi](#readmemd) › [Time](#classestimemd)
 
 ## Class: Time
 
@@ -1573,7 +1556,7 @@ native string
 
 ▪ **MILLISECOND**: *i32* = Time.NANOSECOND * 1000000
 
-*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L978)*
+*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L978)*
 
 ___
 
@@ -1581,7 +1564,7 @@ ___
 
 ▪ **NANOSECOND**: *i32* = 1
 
-*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L977)*
+*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L977)*
 
 ___
 
@@ -1589,7 +1572,7 @@ ___
 
 ▪ **SECOND**: *i32* = Time.MILLISECOND * 1000
 
-*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L979)*
+*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L979)*
 
 ### Methods
 
@@ -1597,7 +1580,7 @@ ___
 
 ▸ **sleep**(`nanoseconds`: i32): *void*
 
-*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L983)*
+*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L983)*
 
 **Parameters:**
 
@@ -1608,9 +1591,9 @@ Name | Type |
 **Returns:** *void*
 
 
-<a name="classes_assembly_as_wasi_wasierrormd"></a>
+<a name="classeswasierrormd"></a>
 
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [WASIError](#classes_assembly_as_wasi_wasierrormd)
+[as-wasi](#readmemd) › [WASIError](#classeswasierrormd)
 
 ## Class: WASIError
 
@@ -1642,11 +1625,11 @@ A WASI error
 
 ####  constructor
 
-\+ **new WASIError**(`message`: string): *[WASIError](#classes_assembly_as_wasi_wasierrormd)*
+\+ **new WASIError**(`message`: string): *[WASIError](#classeswasierrormd)*
 
 *Overrides void*
 
-*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L60)*
+*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L60)*
 
 **Parameters:**
 
@@ -1654,7 +1637,7 @@ Name | Type | Default |
 ------ | ------ | ------ |
 `message` | string | "" |
 
-**Returns:** *[WASIError](#classes_assembly_as_wasi_wasierrormd)*
+**Returns:** *[WASIError](#classeswasierrormd)*
 
 ### Properties
 
@@ -1662,7 +1645,7 @@ Name | Type | Default |
 
 • **message**: *string*
 
-*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[message](#message)*
+*Inherited from [WASIError](#classeswasierrormd).[message](#message)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1578
 
@@ -1674,7 +1657,7 @@ ___
 
 • **name**: *string*
 
-*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[name](#name)*
+*Inherited from [WASIError](#classeswasierrormd).[name](#name)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1575
 
@@ -1686,7 +1669,7 @@ ___
 
 • **stack**? : *undefined | string*
 
-*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[stack](#optional-stack)*
+*Inherited from [WASIError](#classeswasierrormd).[stack](#optional-stack)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1581
 
@@ -1698,183 +1681,10 @@ Stack trace.
 
 ▸ **toString**(): *string*
 
-*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[toString](#tostring)*
+*Inherited from [WASIError](#classeswasierrormd).[toString](#tostring)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1587
 
 Method returns a string representing the specified Error class.
 
 **Returns:** *string*
-
-
-<a name="globalsmd"></a>
-
-[as-wasi](#readmemd) › [Globals](#globalsmd)
-
-# as-wasi
-
-## Index
-
-### Modules
-
-* ["assembly/as-wasi"](#modules_assembly_as_wasi_md)
-* ["assembly/index"](#modules_assembly_index_md)
-
-# Modules
-
-
-<a name="modules_assembly_as_wasi_md"></a>
-
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md)
-
-## Module: "assembly/as-wasi"
-
-### Index
-
-#### Classes
-
-* [CommandLine](#classes_assembly_as_wasi_commandlinemd)
-* [Console](#classes_assembly_as_wasi_consolemd)
-* [Date](#classes_assembly_as_wasi_datemd)
-* [Descriptor](#classes_assembly_as_wasi_descriptormd)
-* [Environ](#classes_assembly_as_wasi_environmd)
-* [EnvironEntry](#classes_assembly_as_wasi_environentrymd)
-* [FileStat](#classes_assembly_as_wasi_filestatmd)
-* [FileSystem](#classes_assembly_as_wasi_filesystemmd)
-* [Performance](#classes_assembly_as_wasi_performancemd)
-* [Process](#classes_assembly_as_wasi_processmd)
-* [Random](#classes_assembly_as_wasi_randommd)
-* [StringUtils](#classes_assembly_as_wasi_stringutilsmd)
-* [Time](#classes_assembly_as_wasi_timemd)
-* [WASIError](#classes_assembly_as_wasi_wasierrormd)
-
-#### Type aliases
-
-* [aisize](#aisize)
-
-#### Functions
-
-* [wasi_abort](#wasi_abort)
-
-### Type aliases
-
-####  aisize
-
-Ƭ **aisize**: *i32*
-
-*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L55)*
-
-### Functions
-
-####  wasi_abort
-
-▸ **wasi_abort**(`message`: string, `fileName`: string, `lineNumber`: u32, `columnNumber`: u32): *void*
-
-*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L1034)*
-
-**Parameters:**
-
-Name | Type | Default |
------- | ------ | ------ |
-`message` | string | "" |
-`fileName` | string | "" |
-`lineNumber` | u32 | 0 |
-`columnNumber` | u32 | 0 |
-
-**Returns:** *void*
-
-
-<a name="modules_assembly_index_md"></a>
-
-[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/index"](#modules_assembly_index_md)
-
-## Module: "assembly/index"
-
-### Index
-
-#### References
-
-* [CommandLine](#commandline)
-* [Console](#console)
-* [Date](#date)
-* [Descriptor](#descriptor)
-* [Environ](#environ)
-* [EnvironEntry](#environentry)
-* [FileStat](#filestat)
-* [FileSystem](#filesystem)
-* [Process](#process)
-* [Random](#random)
-* [Time](#time)
-* [WASIError](#wasierror)
-
-### References
-
-####  CommandLine
-
-• **CommandLine**:
-
-___
-
-####  Console
-
-• **Console**:
-
-___
-
-####  Date
-
-• **Date**:
-
-___
-
-####  Descriptor
-
-• **Descriptor**:
-
-___
-
-####  Environ
-
-• **Environ**:
-
-___
-
-####  EnvironEntry
-
-• **EnvironEntry**:
-
-___
-
-####  FileStat
-
-• **FileStat**:
-
-___
-
-####  FileSystem
-
-• **FileSystem**:
-
-___
-
-####  Process
-
-• **Process**:
-
-___
-
-####  Random
-
-• **Random**:
-
-___
-
-####  Time
-
-• **Time**:
-
-___
-
-####  WASIError
-
-• **WASIError**:

--- a/REFERENCE_API_DOCS.md
+++ b/REFERENCE_API_DOCS.md
@@ -1,87 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-
-- [as-wasi](#as-wasi)
-  - [Index](#index)
-    - [Classes](#classes)
-    - [Type aliases](#type-aliases)
-    - [Functions](#functions)
-  - [Type aliases](#type-aliases-1)
-    - [aisize](#aisize)
-  - [Functions](#functions-1)
-    - [wasi_abort](#wasi_abort)
-- [Classes](#classes-1)
-  - [Class: CommandLine](#class-commandline)
-    - [Hierarchy](#hierarchy)
-    - [Index](#index-1)
-    - [Constructors](#constructors)
-    - [Properties](#properties)
-    - [Methods](#methods)
-  - [Class: Console](#class-console)
-    - [Hierarchy](#hierarchy-1)
-    - [Index](#index-2)
-    - [Methods](#methods-1)
-  - [Class: Date](#class-date)
-    - [Hierarchy](#hierarchy-2)
-    - [Index](#index-3)
-    - [Methods](#methods-2)
-  - [Class: Descriptor](#class-descriptor)
-    - [Hierarchy](#hierarchy-3)
-    - [Index](#index-4)
-    - [Constructors](#constructors-1)
-    - [Accessors](#accessors)
-    - [Methods](#methods-3)
-  - [Class: Environ](#class-environ)
-    - [Hierarchy](#hierarchy-4)
-    - [Index](#index-5)
-    - [Constructors](#constructors-2)
-    - [Properties](#properties-1)
-    - [Methods](#methods-4)
-  - [Class: EnvironEntry](#class-environentry)
-    - [Hierarchy](#hierarchy-5)
-    - [Index](#index-6)
-    - [Constructors](#constructors-3)
-    - [Properties](#properties-2)
-  - [Class: FileStat](#class-filestat)
-    - [Hierarchy](#hierarchy-6)
-    - [Index](#index-7)
-    - [Constructors](#constructors-4)
-    - [Properties](#properties-3)
-  - [Class: FileSystem](#class-filesystem)
-    - [Hierarchy](#hierarchy-7)
-    - [Index](#index-8)
-    - [Methods](#methods-5)
-  - [Class: Performance](#class-performance)
-    - [Hierarchy](#hierarchy-8)
-    - [Index](#index-9)
-    - [Methods](#methods-6)
-  - [Class: Process](#class-process)
-    - [Hierarchy](#hierarchy-9)
-    - [Index](#index-10)
-    - [Methods](#methods-7)
-  - [Class: Random](#class-random)
-    - [Hierarchy](#hierarchy-10)
-    - [Index](#index-11)
-    - [Methods](#methods-8)
-  - [Class: StringUtils](#class-stringutils)
-    - [Hierarchy](#hierarchy-11)
-    - [Index](#index-12)
-    - [Methods](#methods-9)
-  - [Class: Time](#class-time)
-    - [Hierarchy](#hierarchy-12)
-    - [Index](#index-13)
-    - [Properties](#properties-4)
-    - [Methods](#methods-10)
-  - [Class: WASIError](#class-wasierror)
-    - [Hierarchy](#hierarchy-13)
-    - [Index](#index-14)
-    - [Constructors](#constructors-5)
-    - [Properties](#properties-5)
-    - [Methods](#methods-11)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 
 <a name="readmemd"></a>
 
@@ -122,7 +38,7 @@
 
 Ƭ **aisize**: *i32*
 
-*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L55)*
+*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L55)*
 
 ## Functions
 
@@ -130,7 +46,7 @@
 
 ▸ **wasi_abort**(`message`: string, `fileName`: string, `lineNumber`: u32, `columnNumber`: u32): *void*
 
-*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L1034)*
+*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L1034)*
 
 **Parameters:**
 
@@ -177,7 +93,7 @@ Name | Type | Default |
 
 \+ **new CommandLine**(): *[CommandLine](#classescommandlinemd)*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L929)*
 
 **Returns:** *[CommandLine](#classescommandlinemd)*
 
@@ -187,7 +103,7 @@ Name | Type | Default |
 
 • **args**: *string[]*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L929)*
 
 ### Methods
 
@@ -195,7 +111,7 @@ Name | Type | Default |
 
 ▸ **all**(): *Array‹string›*
 
-*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L958)*
+*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L958)*
 
 Return all the command-line arguments
 
@@ -207,7 +123,7 @@ ___
 
 ▸ **get**(`i`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L966)*
+*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L966)*
 
 Return the i-th command-ine argument
 
@@ -245,7 +161,7 @@ Name | Type | Description |
 
 ▸ **error**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L804)*
+*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L804)*
 
 Write an error to the console
 
@@ -264,7 +180,7 @@ ___
 
 ▸ **log**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L795)*
+*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L795)*
 
 Alias for `Console.write()`
 
@@ -282,7 +198,7 @@ ___
 
 ▸ **readAll**(): *string | null*
 
-*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L788)*
+*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L788)*
 
 Read an UTF8 string from the console, convert it to a native string
 
@@ -294,7 +210,7 @@ ___
 
 ▸ **write**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L781)*
+*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L781)*
 
 Write a string to the console
 
@@ -330,7 +246,7 @@ Name | Type | Default | Description |
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L842)*
+*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L842)*
 
 Return the current timestamp, as a number of milliseconds since the epoch
 
@@ -394,7 +310,7 @@ A descriptor, that doesn't necessarily have to represent a file
 
 \+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L109)*
 
 Build a new descriptor from a raw WASI file descriptor
 
@@ -412,7 +328,7 @@ Name | Type | Description |
 
 • **get rawfd**(): *fd*
 
-*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L119)*
+*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L119)*
 
 **Returns:** *fd*
 
@@ -422,7 +338,7 @@ ___
 
 • **get Invalid**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L94)*
+*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L94)*
 
 An invalid file descriptor, that can represent an error
 
@@ -434,7 +350,7 @@ ___
 
 • **get Stderr**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L109)*
 
 The standard error
 
@@ -446,7 +362,7 @@ ___
 
 • **get Stdin**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L99)*
+*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L99)*
 
 The standard input
 
@@ -458,7 +374,7 @@ ___
 
 • **get Stdout**(): *[Descriptor](#classesdescriptormd)*
 
-*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L104)*
+*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L104)*
 
 The standard output
 
@@ -470,7 +386,7 @@ The standard output
 
 ▸ **advise**(`offset`: u64, `len`: u64, `advice`: advice): *bool*
 
-*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L130)*
+*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L130)*
 
 Hint at how the data accessible via the descriptor will be used
 
@@ -498,7 +414,7 @@ ___
 
 ▸ **allocate**(`offset`: u64, `len`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L140)*
+*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L140)*
 
 Preallocate data
 
@@ -519,7 +435,7 @@ ___
 
 ▸ **close**(): *void*
 
-*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L283)*
+*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L283)*
 
 Close a file descriptor
 
@@ -531,7 +447,7 @@ ___
 
 ▸ **dirName**(): *string*
 
-*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L261)*
+*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L261)*
 
 Return the directory associated to that descriptor
 
@@ -543,7 +459,7 @@ ___
 
 ▸ **fatime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L207)*
+*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L207)*
 
 Update the access time
 
@@ -565,7 +481,7 @@ ___
 
 ▸ **fdatasync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L148)*
+*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L148)*
 
 Wait for the data to be written
 
@@ -579,7 +495,7 @@ ___
 
 ▸ **fileType**(): *filetype*
 
-*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L163)*
+*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L163)*
 
 Return the file type
 
@@ -591,7 +507,7 @@ ___
 
 ▸ **fmtime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L219)*
+*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L219)*
 
 Update the modification time
 
@@ -613,7 +529,7 @@ ___
 
 ▸ **fsync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L156)*
+*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L156)*
 
 Wait for the data and metadata to be written
 
@@ -627,7 +543,7 @@ ___
 
 ▸ **ftruncate**(`size`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L198)*
+*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L198)*
 
 Change the size of a file
 
@@ -647,7 +563,7 @@ ___
 
 ▸ **futimes**(`atime`: f64, `mtime`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L232)*
+*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L232)*
 
 Update both the access and the modification times
 
@@ -672,7 +588,7 @@ ___
 
 ▸ **read**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L348)*
+*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L348)*
 
 Read data from a file descriptor
 
@@ -691,7 +607,7 @@ ___
 
 ▸ **readAll**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L373)*
+*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L373)*
 
 Read from a file descriptor until the end of the stream
 
@@ -710,7 +626,7 @@ ___
 
 ▸ **readString**(`chunk_size`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L404)*
+*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L404)*
 
 Read an UTF8 string from a file descriptor, convert it to a native string
 
@@ -728,7 +644,7 @@ ___
 
 ▸ **seek**(`off`: u64, `w`: whence): *bool*
 
-*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L418)*
+*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L418)*
 
 Seek into a stream
 
@@ -751,7 +667,7 @@ ___
 
 ▸ **setFlags**(`flags`: fdflags): *bool*
 
-*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L177)*
+*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L177)*
 
 Set WASI flags for that descriptor
 
@@ -773,7 +689,7 @@ ___
 
 ▸ **stat**(): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L185)*
+*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L185)*
 
 Retrieve information about a descriptor
 
@@ -787,7 +703,7 @@ ___
 
 ▸ **tell**(): *u64*
 
-*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L429)*
+*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L429)*
 
 Return the current offset in the stream
 
@@ -801,7 +717,7 @@ ___
 
 ▸ **touch**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L247)*
+*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L247)*
 
 Update the timestamp of the object represented by the descriptor
 
@@ -815,7 +731,7 @@ ___
 
 ▸ **write**(`data`: u8[]): *void*
 
-*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L291)*
+*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L291)*
 
 Write data to a file descriptor
 
@@ -833,7 +749,7 @@ ___
 
 ▸ **writeString**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L309)*
+*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L309)*
 
 Write a string to a file descriptor, after encoding it to UTF8
 
@@ -852,7 +768,7 @@ ___
 
 ▸ **writeStringLn**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L328)*
+*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L328)*
 
 Write a string to a file descriptor, after encoding it to UTF8, with a newline
 
@@ -896,7 +812,7 @@ Name | Type | Description |
 
 \+ **new Environ**(): *[Environ](#classesenvironmd)*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L877)*
 
 **Returns:** *[Environ](#classesenvironmd)*
 
@@ -906,7 +822,7 @@ Name | Type | Description |
 
 • **env**: *Array‹[EnvironEntry](#classesenvironentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L877)*
 
 ### Methods
 
@@ -914,7 +830,7 @@ Name | Type | Description |
 
 ▸ **all**(): *Array‹[EnvironEntry](#classesenvironentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L908)*
+*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L908)*
 
  Return all environment variables
 
@@ -926,7 +842,7 @@ ___
 
 ▸ **get**(`key`: string): *string | null*
 
-*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L916)*
+*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L916)*
 
 Return the value for an environment variable
 
@@ -966,7 +882,7 @@ Name | Type | Description |
 
 \+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classesenvironentrymd)*
 
-*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L872)*
+*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L872)*
 
 **Parameters:**
 
@@ -983,7 +899,7 @@ Name | Type |
 
 • **key**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L873)*
 
 ___
 
@@ -991,7 +907,7 @@ ___
 
 • **value**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L873)*
 
 
 <a name="classesfilestatmd"></a>
@@ -1026,7 +942,7 @@ Portable information about a file
 
 \+ **new FileStat**(`st_buf`: usize): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L75)*
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L75)*
 
 **Parameters:**
 
@@ -1042,7 +958,7 @@ Name | Type |
 
 • **access_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:73](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L73)*
+*Defined in [assembly/as-wasi.ts:73](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L73)*
 
 ___
 
@@ -1050,7 +966,7 @@ ___
 
 • **creation_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L75)*
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L75)*
 
 ___
 
@@ -1058,7 +974,7 @@ ___
 
 • **file_size**: *filesize*
 
-*Defined in [assembly/as-wasi.ts:72](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L72)*
+*Defined in [assembly/as-wasi.ts:72](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L72)*
 
 ___
 
@@ -1066,7 +982,7 @@ ___
 
 • **file_type**: *filetype*
 
-*Defined in [assembly/as-wasi.ts:71](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L71)*
+*Defined in [assembly/as-wasi.ts:71](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L71)*
 
 ___
 
@@ -1074,7 +990,7 @@ ___
 
 • **modification_time**: *f64*
 
-*Defined in [assembly/as-wasi.ts:74](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L74)*
+*Defined in [assembly/as-wasi.ts:74](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L74)*
 
 
 <a name="classesfilesystemmd"></a>
@@ -1112,7 +1028,7 @@ A class to access a filesystem
 
 ▸ **dirfdForPath**(`path`: string): *fd*
 
-*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L769)*
+*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L769)*
 
 **Parameters:**
 
@@ -1128,7 +1044,7 @@ ___
 
 ▸ **exists**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L533)*
+*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L533)*
 
 Check if a file exists at a given path
 
@@ -1150,7 +1066,7 @@ ___
 
 ▸ **link**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L556)*
+*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L556)*
 
 Create a hard link
 
@@ -1175,7 +1091,7 @@ ___
 
 ▸ **lstat**(`path`: string): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L672)*
+*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L672)*
 
 Retrieve information about a file or a symbolic link
 
@@ -1197,7 +1113,7 @@ ___
 
 ▸ **mkdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L516)*
+*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L516)*
 
 Create a new directory
 
@@ -1219,7 +1135,7 @@ ___
 
 ▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classesdescriptormd) | null*
 
-*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L449)*
+*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L449)*
 
 Open a path
 
@@ -1244,7 +1160,7 @@ ___
 
 ▸ **readdir**(`path`: string): *Array‹string› | null*
 
-*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L726)*
+*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L726)*
 
 Get the content of a directory
 
@@ -1264,7 +1180,7 @@ ___
 
 ▸ **rename**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L698)*
+*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L698)*
 
 Rename a file
 
@@ -1289,7 +1205,7 @@ ___
 
 ▸ **rmdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L630)*
+*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L630)*
 
 Remove a directory
 
@@ -1311,7 +1227,7 @@ ___
 
 ▸ **stat**(`path`: string): *[FileStat](#classesfilestatmd)*
 
-*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L647)*
+*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L647)*
 
 Retrieve information about a file
 
@@ -1333,7 +1249,7 @@ ___
 
 ▸ **symlink**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L587)*
+*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L587)*
 
 Create a symbolic link
 
@@ -1358,7 +1274,7 @@ ___
 
 ▸ **unlink**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L613)*
+*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L613)*
 
 Unlink a file
 
@@ -1397,7 +1313,7 @@ Name | Type |
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L852)*
+*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L852)*
 
 **Returns:** *f64*
 
@@ -1424,7 +1340,7 @@ Name | Type |
 
 ▸ **exit**(`status`: u32): *void*
 
-*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L867)*
+*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L867)*
 
 Cleanly terminate the current process
 
@@ -1460,7 +1376,7 @@ Name | Type | Description |
 
 ▸ **randomBytes**(`len`: usize): *Uint8Array*
 
-*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L831)*
+*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L831)*
 
 Return an array of random bytes
 
@@ -1478,7 +1394,7 @@ ___
 
 ▸ **randomFill**(`buffer`: ArrayBuffer): *void*
 
-*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L814)*
+*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L814)*
 
 Fill a buffer with random data
 
@@ -1513,7 +1429,7 @@ Name | Type | Description |
 
 ▸ **fromCString**(`cstring`: usize): *string*
 
-*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L1023)*
+*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L1023)*
 
 Returns a native string from a zero-terminated C string
 
@@ -1556,7 +1472,7 @@ native string
 
 ▪ **MILLISECOND**: *i32* = Time.NANOSECOND * 1000000
 
-*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L978)*
+*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L978)*
 
 ___
 
@@ -1564,7 +1480,7 @@ ___
 
 ▪ **NANOSECOND**: *i32* = 1
 
-*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L977)*
+*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L977)*
 
 ___
 
@@ -1572,7 +1488,7 @@ ___
 
 ▪ **SECOND**: *i32* = Time.MILLISECOND * 1000
 
-*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L979)*
+*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L979)*
 
 ### Methods
 
@@ -1580,7 +1496,7 @@ ___
 
 ▸ **sleep**(`nanoseconds`: i32): *void*
 
-*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L983)*
+*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L983)*
 
 **Parameters:**
 
@@ -1629,7 +1545,7 @@ A WASI error
 
 *Overrides void*
 
-*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/c086d5c/assembly/as-wasi.ts#L60)*
+*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/4ce0170/assembly/as-wasi.ts#L60)*
 
 **Parameters:**
 

--- a/REFERENCE_API_DOCS.md
+++ b/REFERENCE_API_DOCS.md
@@ -2,418 +2,170 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [assemblyscript](#assemblyscript)
-- [Standard library](#standard-library)
+- [as-wasi](#as-wasi)
+- [as-wasi](#as-wasi-1)
+  - [Installation](#installation)
+  - [Quick Start](#quick-start)
+  - [Reference API Docs](#reference-api-docs)
+  - [Projects using as-wasi](#projects-using-as-wasi)
+  - [Contributing](#contributing)
+  - [License](#license)
 - [Classes](#classes)
-  - [Class: $event](#class-event)
+  - [Class: CommandLine](#class-commandline)
     - [Hierarchy](#hierarchy)
     - [Index](#index)
-    - [Properties](#properties)
-  - [Class: $prestat](#class-prestat)
-    - [Hierarchy](#hierarchy-1)
-    - [Index](#index-1)
-    - [Properties](#properties-1)
-  - [Class: $subscription](#class-subscription)
-    - [Hierarchy](#hierarchy-2)
-    - [Index](#index-2)
-    - [Properties](#properties-2)
-  - [Class: CommandLine](#class-commandline)
-    - [Hierarchy](#hierarchy-3)
-    - [Index](#index-3)
     - [Constructors](#constructors)
-    - [Properties](#properties-3)
+    - [Properties](#properties)
     - [Methods](#methods)
   - [Class: Console](#class-console)
-    - [Hierarchy](#hierarchy-4)
-    - [Index](#index-4)
+    - [Hierarchy](#hierarchy-1)
+    - [Index](#index-1)
     - [Methods](#methods-1)
   - [Class: Date](#class-date)
-    - [Hierarchy](#hierarchy-5)
-    - [Index](#index-5)
+    - [Hierarchy](#hierarchy-2)
+    - [Index](#index-2)
     - [Methods](#methods-2)
   - [Class: Descriptor](#class-descriptor)
-    - [Hierarchy](#hierarchy-6)
-    - [Index](#index-6)
+    - [Hierarchy](#hierarchy-3)
+    - [Index](#index-3)
     - [Constructors](#constructors-1)
     - [Accessors](#accessors)
     - [Methods](#methods-3)
-  - [Class: dirent](#class-dirent)
-    - [Hierarchy](#hierarchy-7)
-    - [Index](#index-7)
-    - [Properties](#properties-4)
   - [Class: Environ](#class-environ)
-    - [Hierarchy](#hierarchy-8)
-    - [Index](#index-8)
+    - [Hierarchy](#hierarchy-4)
+    - [Index](#index-4)
     - [Constructors](#constructors-2)
-    - [Properties](#properties-5)
+    - [Properties](#properties-1)
     - [Methods](#methods-4)
   - [Class: EnvironEntry](#class-environentry)
+    - [Hierarchy](#hierarchy-5)
+    - [Index](#index-5)
+    - [Constructors](#constructors-3)
+    - [Properties](#properties-2)
+  - [Class: FileStat](#class-filestat)
+    - [Hierarchy](#hierarchy-6)
+    - [Index](#index-6)
+    - [Constructors](#constructors-4)
+    - [Properties](#properties-3)
+  - [Class: FileSystem](#class-filesystem)
+    - [Hierarchy](#hierarchy-7)
+    - [Index](#index-7)
+    - [Methods](#methods-5)
+  - [Class: Performance](#class-performance)
+    - [Hierarchy](#hierarchy-8)
+    - [Index](#index-8)
+    - [Methods](#methods-6)
+  - [Class: Process](#class-process)
     - [Hierarchy](#hierarchy-9)
     - [Index](#index-9)
-    - [Constructors](#constructors-3)
-    - [Properties](#properties-6)
-  - [Class: event](#class-event)
-    - [Hierarchy](#hierarchy-10)
-    - [Index](#index-10)
-    - [Properties](#properties-7)
-  - [Class: event_fd_readwrite](#class-event_fd_readwrite)
-    - [Hierarchy](#hierarchy-11)
-    - [Index](#index-11)
-    - [Properties](#properties-8)
-  - [Class: fdstat](#class-fdstat)
-    - [Hierarchy](#hierarchy-12)
-    - [Index](#index-12)
-    - [Properties](#properties-9)
-  - [Class: filestat](#class-filestat)
-    - [Hierarchy](#hierarchy-13)
-    - [Index](#index-13)
-    - [Properties](#properties-10)
-  - [Class: FileSystem](#class-filesystem)
-    - [Hierarchy](#hierarchy-14)
-    - [Index](#index-14)
-    - [Methods](#methods-5)
-  - [Class: iovec](#class-iovec)
-    - [Hierarchy](#hierarchy-15)
-    - [Index](#index-15)
-    - [Properties](#properties-11)
-  - [Class: Performance](#class-performance)
-    - [Hierarchy](#hierarchy-16)
-    - [Index](#index-16)
-    - [Methods](#methods-6)
-  - [Class: prestat](#class-prestat)
-    - [Hierarchy](#hierarchy-17)
-    - [Index](#index-17)
-    - [Properties](#properties-12)
-  - [Class: prestat_dir](#class-prestat_dir)
-    - [Hierarchy](#hierarchy-18)
-    - [Index](#index-18)
-    - [Properties](#properties-13)
-  - [Class: Process](#class-process)
-    - [Hierarchy](#hierarchy-19)
-    - [Index](#index-19)
     - [Methods](#methods-7)
   - [Class: Random](#class-random)
-    - [Hierarchy](#hierarchy-20)
-    - [Index](#index-20)
+    - [Hierarchy](#hierarchy-10)
+    - [Index](#index-10)
     - [Methods](#methods-8)
   - [Class: StringUtils](#class-stringutils)
-    - [Hierarchy](#hierarchy-21)
-    - [Index](#index-21)
+    - [Hierarchy](#hierarchy-11)
+    - [Index](#index-11)
     - [Methods](#methods-9)
-  - [Class: subscription](#class-subscription)
-    - [Hierarchy](#hierarchy-22)
-    - [Index](#index-22)
-    - [Properties](#properties-14)
-  - [Class: subscription_clock](#class-subscription_clock)
-    - [Hierarchy](#hierarchy-23)
-    - [Index](#index-23)
-    - [Properties](#properties-15)
-  - [Class: subscription_fd_readwrite](#class-subscription_fd_readwrite)
-    - [Hierarchy](#hierarchy-24)
-    - [Index](#index-24)
-    - [Properties](#properties-16)
   - [Class: Time](#class-time)
-    - [Hierarchy](#hierarchy-25)
-    - [Index](#index-25)
-    - [Properties](#properties-17)
+    - [Hierarchy](#hierarchy-12)
+    - [Index](#index-12)
+    - [Properties](#properties-4)
     - [Methods](#methods-10)
   - [Class: WASIError](#class-wasierror)
-    - [Hierarchy](#hierarchy-26)
-    - [Index](#index-26)
-    - [Constructors](#constructors-4)
-    - [Properties](#properties-18)
+    - [Hierarchy](#hierarchy-13)
+    - [Index](#index-13)
+    - [Constructors](#constructors-5)
+    - [Properties](#properties-5)
     - [Methods](#methods-11)
-- [assemblyscript](#assemblyscript-1)
-  - [Index](#index-27)
-    - [Namespaces](#namespaces)
-    - [Classes](#classes-1)
+- [as-wasi](#as-wasi-2)
+  - [Index](#index-14)
+    - [Modules](#modules)
+- [Modules](#modules-1)
+  - [Module: "assembly/as-wasi"](#module-assemblyas-wasi)
+    - [Index](#index-15)
     - [Type aliases](#type-aliases)
     - [Functions](#functions)
-  - [Type aliases](#type-aliases-1)
-    - [aisize](#aisize)
-    - [char](#char)
-    - [device](#device)
-    - [dircookie](#dircookie)
-    - [exitcode](#exitcode)
-    - [fd](#fd)
-    - [filedelta](#filedelta)
-    - [filesize](#filesize)
-    - [inode](#inode)
-    - [linkcount](#linkcount)
-    - [ptr](#ptr)
-    - [struct](#struct)
-    - [timestamp](#timestamp)
-    - [userdata](#userdata)
-  - [Functions](#functions-1)
-    - [args_get](#args_get)
-    - [args_sizes_get](#args_sizes_get)
-    - [clock_res_get](#clock_res_get)
-    - [clock_time_get](#clock_time_get)
-    - [environ_get](#environ_get)
-    - [environ_sizes_get](#environ_sizes_get)
-    - [fd_advise](#fd_advise)
-    - [fd_allocate](#fd_allocate)
-    - [fd_close](#fd_close)
-    - [fd_datasync](#fd_datasync)
-    - [fd_fdstat_get](#fd_fdstat_get)
-    - [fd_fdstat_set_flags](#fd_fdstat_set_flags)
-    - [fd_fdstat_set_rights](#fd_fdstat_set_rights)
-    - [fd_filestat_get](#fd_filestat_get)
-    - [fd_filestat_set_size](#fd_filestat_set_size)
-    - [fd_filestat_set_times](#fd_filestat_set_times)
-    - [fd_pread](#fd_pread)
-    - [fd_prestat_dir_name](#fd_prestat_dir_name)
-    - [fd_prestat_get](#fd_prestat_get)
-    - [fd_pwrite](#fd_pwrite)
-    - [fd_read](#fd_read)
-    - [fd_readdir](#fd_readdir)
-    - [fd_renumber](#fd_renumber)
-    - [fd_seek](#fd_seek)
-    - [fd_sync](#fd_sync)
-    - [fd_tell](#fd_tell)
-    - [fd_write](#fd_write)
-    - [path_create_directory](#path_create_directory)
-    - [path_filestat_get](#path_filestat_get)
-    - [path_filestat_set_times](#path_filestat_set_times)
-    - [path_link](#path_link)
-    - [path_open](#path_open)
-    - [path_readlink](#path_readlink)
-    - [path_remove_directory](#path_remove_directory)
-    - [path_rename](#path_rename)
-    - [path_symlink](#path_symlink)
-    - [path_unlink_file](#path_unlink_file)
-    - [poll_oneoff](#poll_oneoff)
-    - [proc_exit](#proc_exit)
-    - [proc_raise](#proc_raise)
-    - [random_get](#random_get)
-    - [sched_yield](#sched_yield)
-    - [sock_recv](#sock_recv)
-    - [sock_send](#sock_send)
-    - [sock_shutdown](#sock_shutdown)
-    - [wasi_abort](#wasi_abort)
-- [Modules](#modules)
-  - [Namespace: advice](#namespace-advice)
-    - [Index](#index-28)
-    - [Variables](#variables)
-  - [Namespace: clockid](#namespace-clockid)
-    - [Index](#index-29)
-    - [Variables](#variables-1)
-  - [Namespace: errno](#namespace-errno)
-    - [Index](#index-30)
-    - [Variables](#variables-2)
-  - [Namespace: eventrwflags](#namespace-eventrwflags)
-    - [Index](#index-31)
-    - [Variables](#variables-3)
-  - [Namespace: eventtype](#namespace-eventtype)
-    - [Index](#index-32)
-    - [Variables](#variables-4)
-  - [Namespace: fdflags](#namespace-fdflags)
-    - [Index](#index-33)
-    - [Variables](#variables-5)
-  - [Namespace: filetype](#namespace-filetype)
-    - [Index](#index-34)
-    - [Variables](#variables-6)
-  - [Namespace: fstflags](#namespace-fstflags)
-    - [Index](#index-35)
-    - [Variables](#variables-7)
-  - [Namespace: lookupflags](#namespace-lookupflags)
-    - [Index](#index-36)
-    - [Variables](#variables-8)
-  - [Namespace: oflags](#namespace-oflags)
-    - [Index](#index-37)
-    - [Variables](#variables-9)
-  - [Namespace: preopentype](#namespace-preopentype)
-    - [Index](#index-38)
-    - [Variables](#variables-10)
-  - [Namespace: riflags](#namespace-riflags)
-    - [Index](#index-39)
-    - [Variables](#variables-11)
-  - [Namespace: rights](#namespace-rights)
-    - [Index](#index-40)
-    - [Variables](#variables-12)
-  - [Namespace: roflags](#namespace-roflags)
-    - [Index](#index-41)
-    - [Variables](#variables-13)
-  - [Namespace: sdflags](#namespace-sdflags)
-    - [Index](#index-42)
-    - [Variables](#variables-14)
-  - [Namespace: siflags](#namespace-siflags)
-  - [Namespace: signal](#namespace-signal)
-    - [Index](#index-43)
-    - [Variables](#variables-15)
-  - [Namespace: subclockflags](#namespace-subclockflags)
-    - [Index](#index-44)
-    - [Variables](#variables-16)
-  - [Namespace: whence](#namespace-whence)
-    - [Index](#index-45)
-    - [Variables](#variables-17)
+  - [Module: "assembly/index"](#module-assemblyindex)
+    - [Index](#index-16)
+    - [References](#references)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 <a name="readmemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd)
 
-# assemblyscript
+# as-wasi
 
-Standard library
-================
+# as-wasi
 
-Standard library components for use with `tsc` (portable) and `asc` (assembly).
+<!--- Badges -->
 
-Base configurations (.json) and definition files (.d.ts) are relevant to `tsc` only and not used by `asc`.
+![npm version](https://img.shields.io/npm/v/as-wasi.svg)
+![npm downloads per month](https://img.shields.io/npm/dm/as-wasi.svg)
+![GitHub License](https://img.shields.io/github/license/torch2424/as-wasi.svg)
+
+<!--- Short Description-->
+
+A high-level AssemblyScript layer for the WebAssembly System Interface (WASI).
+
+[WASI](https://wasi.dev) is an API providing access to the external world to WebAssembly modules. AssemblyScript exposes the low-level WASI standard set of system calls. `as-wasi` builds a higher level API on top of the AssemblyScript WASI interface, at a similar level to the [Node API](https://nodejs.org/docs/latest/api/).
+
+## Installation
+
+You can install `as-wasi` in your project by running the following:
+
+`npm install --save as-bind`
+
+## Quick Start
+
+Example usage of the `Console` and `Environ` classes:
+
+```typescript
+// Import from the installed as-wasi package
+import { Console, Environ } from "as-wasi";
+
+// Create an envrion instance
+let env = new Environ();
+
+// Get the HOME Environment variable
+let home = env.get("HOME")!;
+
+// Log the HOME string to stdout
+Console.log(home);
+```
+
+## Reference API Docs
+
+Reference API documentation can be found in [REFERENCE_API_DOCS](./REFERENCE_API_DOCS.md).
+
+## Projects using as-wasi
+
+* [wasmboy](https://github.com/torch2424/wasmboy) - Game Boy / Game Boy Color Emulator Library, 🎮written for WebAssembly using AssemblyScript. 🚀
+* [wasmerio/io-devices-lib](https://github.com/wasmerio/io-devices-lib) - Library for interacting with the Wasmer Experimental IO Devices API. Uses WASI for outputting graphics in a framebuffer, and handles mouse/keyboard input.
+* [wasm-by-example](https://github.com/torch2424/wasm-by-example) - Wasm By Example is a website with a set of hands-on introduction examples and tutorials for WebAssembly (Wasm). Wasm By Example features `as-wasi` by default for the AssemblyScript WASI examples.
+* [wasm-matrix](https://github.com/torch2424/wasm-matrix) - A Matrix effect in your terminal using AssemblyScript 🚀 and WASI 🧩 . THhise project is a bit older, and uses an older version of `as-wasi`, but still creates a cool effect!
+
+_If you're project is using as-wasi, and you would like to be featured here. Please open a README with links to your project, and if appropriate, explaining how as-wasi is being used._ 😊
+
+## Contributing
+
+Contributions are definitely welcome! Feel free to open a PR for small fixes such as typos and things. Larger fixes, or new features should start out as an issue for discussion, in which then a PR should be made. 🥳
+
+This project will also adhere to the [AssemblyScript Code of Conduct](https://github.com/AssemblyScript/assemblyscript/blob/master/CODE_OF_CONDUCT.md).
+
+## License
+
+[MIT](https://oss.ninja/mit/jesdict1). 📝
 
 # Classes
 
 
-<a name="classes_eventmd"></a>
+<a name="classes_assembly_as_wasi_commandlinemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$event](#classes_eventmd)
-
-## Class: $event
-
-### Hierarchy
-
-* **$event**
-
-  ↳ [event](#classeseventmd)
-
-  ↳ [event_fd_readwrite](#classesevent_fd_readwritemd)
-
-### Index
-
-#### Properties
-
-* [__padding0](#private-__padding0)
-* [error](#error)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding0
-
-• **__padding0**: *u16*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:970
-
-___
-
-####  error
-
-• **error**: *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
-
-If non-zero, an error that occurred while processing the subscription request.
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
-
-The type of the event that occurred.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
-
-User-provided value that got attached to `subscription#userdata`.
-
-
-<a name="classes_prestatmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$prestat](#classes_prestatmd)
-
-## Class: $prestat
-
-### Hierarchy
-
-* **$prestat**
-
-  ↳ [prestat](#classesprestatmd)
-
-  ↳ [prestat_dir](#classesprestat_dirmd)
-
-### Index
-
-#### Properties
-
-* [type](#type)
-
-### Properties
-
-####  type
-
-• **type**: *[preopentype](#modulespreopentypemd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
-
-
-<a name="classes_subscriptionmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$subscription](#classes_subscriptionmd)
-
-## Class: $subscription
-
-### Hierarchy
-
-* **$subscription**
-
-  ↳ [subscription](#classessubscriptionmd)
-
-  ↳ [subscription_clock](#classessubscription_clockmd)
-
-  ↳ [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
-
-### Index
-
-#### Properties
-
-* [__padding0](#private-__padding0)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding0
-
-• **__padding0**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1509
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
-
-The type of the event to which to subscribe.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
-
-User-provided value that is attached to the subscription.
-
-
-<a name="classescommandlinemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [CommandLine](#classescommandlinemd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [CommandLine](#classes_assembly_as_wasi_commandlinemd)
 
 ## Class: CommandLine
 
@@ -440,11 +192,11 @@ User-provided value that is attached to the subscription.
 
 ####  constructor
 
-\+ **new CommandLine**(): *[CommandLine](#classescommandlinemd)*
+\+ **new CommandLine**(): *[CommandLine](#classes_assembly_as_wasi_commandlinemd)*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L929)*
 
-**Returns:** *[CommandLine](#classescommandlinemd)*
+**Returns:** *[CommandLine](#classes_assembly_as_wasi_commandlinemd)*
 
 ### Properties
 
@@ -452,7 +204,7 @@ User-provided value that is attached to the subscription.
 
 • **args**: *string[]*
 
-*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L929)*
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L929)*
 
 ### Methods
 
@@ -460,7 +212,7 @@ User-provided value that is attached to the subscription.
 
 ▸ **all**(): *Array‹string›*
 
-*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L958)*
+*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L958)*
 
 Return all the command-line arguments
 
@@ -472,7 +224,7 @@ ___
 
 ▸ **get**(`i`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L966)*
+*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L966)*
 
 Return the i-th command-ine argument
 
@@ -485,9 +237,9 @@ Name | Type | Description |
 **Returns:** *string | null*
 
 
-<a name="classesconsolemd"></a>
+<a name="classes_assembly_as_wasi_consolemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Console](#classesconsolemd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Console](#classes_assembly_as_wasi_consolemd)
 
 ## Class: Console
 
@@ -510,7 +262,7 @@ Name | Type | Description |
 
 ▸ **error**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L804)*
+*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L804)*
 
 Write an error to the console
 
@@ -529,7 +281,7 @@ ___
 
 ▸ **log**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L795)*
+*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L795)*
 
 Alias for `Console.write()`
 
@@ -547,7 +299,7 @@ ___
 
 ▸ **readAll**(): *string | null*
 
-*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L788)*
+*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L788)*
 
 Read an UTF8 string from the console, convert it to a native string
 
@@ -559,7 +311,7 @@ ___
 
 ▸ **write**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L781)*
+*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L781)*
 
 Write a string to the console
 
@@ -573,9 +325,9 @@ Name | Type | Default | Description |
 **Returns:** *void*
 
 
-<a name="classesdatemd"></a>
+<a name="classes_assembly_as_wasi_datemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Date](#classesdatemd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Date](#classes_assembly_as_wasi_datemd)
 
 ## Class: Date
 
@@ -595,16 +347,16 @@ Name | Type | Default | Description |
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L842)*
+*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L842)*
 
 Return the current timestamp, as a number of milliseconds since the epoch
 
 **Returns:** *f64*
 
 
-<a name="classesdescriptormd"></a>
+<a name="classes_assembly_as_wasi_descriptormd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Descriptor](#classesdescriptormd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Descriptor](#classes_assembly_as_wasi_descriptormd)
 
 ## Class: Descriptor
 
@@ -657,9 +409,9 @@ A descriptor, that doesn't necessarily have to represent a file
 
 ####  constructor
 
-\+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classesdescriptormd)*
+\+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L109)*
 
 Build a new descriptor from a raw WASI file descriptor
 
@@ -669,7 +421,7 @@ Name | Type | Description |
 ------ | ------ | ------ |
 `rawfd` | fd | a raw file descriptor  |
 
-**Returns:** *[Descriptor](#classesdescriptormd)*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
 ### Accessors
 
@@ -677,7 +429,7 @@ Name | Type | Description |
 
 • **get rawfd**(): *fd*
 
-*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L119)*
+*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L119)*
 
 **Returns:** *fd*
 
@@ -685,49 +437,49 @@ ___
 
 #### `Static` Invalid
 
-• **get Invalid**(): *[Descriptor](#classesdescriptormd)*
+• **get Invalid**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
-*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L94)*
+*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L94)*
 
 An invalid file descriptor, that can represent an error
 
-**Returns:** *[Descriptor](#classesdescriptormd)*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
 ___
 
 #### `Static` Stderr
 
-• **get Stderr**(): *[Descriptor](#classesdescriptormd)*
+• **get Stderr**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
-*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L109)*
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L109)*
 
 The standard error
 
-**Returns:** *[Descriptor](#classesdescriptormd)*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
 ___
 
 #### `Static` Stdin
 
-• **get Stdin**(): *[Descriptor](#classesdescriptormd)*
+• **get Stdin**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
-*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L99)*
+*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L99)*
 
 The standard input
 
-**Returns:** *[Descriptor](#classesdescriptormd)*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
 ___
 
 #### `Static` Stdout
 
-• **get Stdout**(): *[Descriptor](#classesdescriptormd)*
+• **get Stdout**(): *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
-*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L104)*
+*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L104)*
 
 The standard output
 
-**Returns:** *[Descriptor](#classesdescriptormd)*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd)*
 
 ### Methods
 
@@ -735,7 +487,7 @@ The standard output
 
 ▸ **advise**(`offset`: u64, `len`: u64, `advice`: advice): *bool*
 
-*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L130)*
+*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L130)*
 
 Hint at how the data accessible via the descriptor will be used
 
@@ -763,7 +515,7 @@ ___
 
 ▸ **allocate**(`offset`: u64, `len`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L140)*
+*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L140)*
 
 Preallocate data
 
@@ -784,7 +536,7 @@ ___
 
 ▸ **close**(): *void*
 
-*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L283)*
+*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L283)*
 
 Close a file descriptor
 
@@ -796,7 +548,7 @@ ___
 
 ▸ **dirName**(): *string*
 
-*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L261)*
+*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L261)*
 
 Return the directory associated to that descriptor
 
@@ -808,7 +560,7 @@ ___
 
 ▸ **fatime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L207)*
+*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L207)*
 
 Update the access time
 
@@ -830,7 +582,7 @@ ___
 
 ▸ **fdatasync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L148)*
+*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L148)*
 
 Wait for the data to be written
 
@@ -842,13 +594,13 @@ ___
 
 ####  fileType
 
-▸ **fileType**(): *[filetype](#filetype)*
+▸ **fileType**(): *filetype*
 
-*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L163)*
+*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L163)*
 
 Return the file type
 
-**Returns:** *[filetype](#filetype)*
+**Returns:** *filetype*
 
 ___
 
@@ -856,7 +608,7 @@ ___
 
 ▸ **fmtime**(`ts`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L219)*
+*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L219)*
 
 Update the modification time
 
@@ -878,7 +630,7 @@ ___
 
 ▸ **fsync**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L156)*
+*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L156)*
 
 Wait for the data and metadata to be written
 
@@ -892,7 +644,7 @@ ___
 
 ▸ **ftruncate**(`size`: u64): *bool*
 
-*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L198)*
+*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L198)*
 
 Change the size of a file
 
@@ -912,7 +664,7 @@ ___
 
 ▸ **futimes**(`atime`: f64, `mtime`: f64): *bool*
 
-*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L232)*
+*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L232)*
 
 Update both the access and the modification times
 
@@ -937,7 +689,7 @@ ___
 
 ▸ **read**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L348)*
+*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L348)*
 
 Read data from a file descriptor
 
@@ -956,7 +708,7 @@ ___
 
 ▸ **readAll**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
 
-*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L373)*
+*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L373)*
 
 Read from a file descriptor until the end of the stream
 
@@ -975,7 +727,7 @@ ___
 
 ▸ **readString**(`chunk_size`: usize): *string | null*
 
-*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L404)*
+*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L404)*
 
 Read an UTF8 string from a file descriptor, convert it to a native string
 
@@ -993,7 +745,7 @@ ___
 
 ▸ **seek**(`off`: u64, `w`: whence): *bool*
 
-*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L418)*
+*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L418)*
 
 Seek into a stream
 
@@ -1014,9 +766,9 @@ ___
 
 ####  setFlags
 
-▸ **setFlags**(`flags`: [fdflags](#modulesfdflagsmd)): *bool*
+▸ **setFlags**(`flags`: fdflags): *bool*
 
-*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L177)*
+*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L177)*
 
 Set WASI flags for that descriptor
 
@@ -1026,7 +778,7 @@ Set WASI flags for that descriptor
 
 Name | Type |
 ------ | ------ |
-`flags` | [fdflags](#modulesfdflagsmd) |
+`flags` | fdflags |
 
 **Returns:** *bool*
 
@@ -1036,13 +788,13 @@ ___
 
 ####  stat
 
-▸ **stat**(): *[FileStat](#classesfilestatmd)*
+▸ **stat**(): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
-*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L185)*
+*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L185)*
 
 Retrieve information about a descriptor
 
-**Returns:** *[FileStat](#classesfilestatmd)*
+**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
 a `FileStat` object`
 
@@ -1052,7 +804,7 @@ ___
 
 ▸ **tell**(): *u64*
 
-*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L429)*
+*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L429)*
 
 Return the current offset in the stream
 
@@ -1066,7 +818,7 @@ ___
 
 ▸ **touch**(): *bool*
 
-*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L247)*
+*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L247)*
 
 Update the timestamp of the object represented by the descriptor
 
@@ -1080,7 +832,7 @@ ___
 
 ▸ **write**(`data`: u8[]): *void*
 
-*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L291)*
+*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L291)*
 
 Write data to a file descriptor
 
@@ -1098,7 +850,7 @@ ___
 
 ▸ **writeString**(`s`: string, `newline`: bool): *void*
 
-*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L309)*
+*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L309)*
 
 Write a string to a file descriptor, after encoding it to UTF8
 
@@ -1117,7 +869,7 @@ ___
 
 ▸ **writeStringLn**(`s`: string): *void*
 
-*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L328)*
+*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L328)*
 
 Write a string to a file descriptor, after encoding it to UTF8, with a newline
 
@@ -1130,80 +882,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classesdirentmd"></a>
+<a name="classes_assembly_as_wasi_environmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [dirent](#classesdirentmd)
-
-## Class: dirent
-
-A directory entry.
-
-### Hierarchy
-
-* **dirent**
-
-### Index
-
-#### Properties
-
-* [__padding0](#private-__padding0)
-* [ino](#ino)
-* [namlen](#namlen)
-* [next](#next)
-* [type](#type)
-
-### Properties
-
-#### `Private` __padding0
-
-• **__padding0**: *u16*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:646
-
-___
-
-####  ino
-
-• **ino**: *[inode](#inode)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:641
-
-The serial number of the file referred to by this directory entry.
-
-___
-
-####  namlen
-
-• **namlen**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:643
-
-The length of the name of the directory entry.
-
-___
-
-####  next
-
-• **next**: *[dircookie](#dircookie)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:639
-
-The offset of the next directory entry stored in this directory.
-
-___
-
-####  type
-
-• **type**: *[filetype](#filetype)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:645
-
-The type of the file referred to by this directory entry.
-
-
-<a name="classesenvironmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Environ](#classesenvironmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Environ](#classes_assembly_as_wasi_environmd)
 
 ## Class: Environ
 
@@ -1230,31 +911,31 @@ The type of the file referred to by this directory entry.
 
 ####  constructor
 
-\+ **new Environ**(): *[Environ](#classesenvironmd)*
+\+ **new Environ**(): *[Environ](#classes_assembly_as_wasi_environmd)*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L877)*
 
-**Returns:** *[Environ](#classesenvironmd)*
+**Returns:** *[Environ](#classes_assembly_as_wasi_environmd)*
 
 ### Properties
 
 ####  env
 
-• **env**: *Array‹[EnvironEntry](#classesenvironentrymd)›*
+• **env**: *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L877)*
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L877)*
 
 ### Methods
 
 ####  all
 
-▸ **all**(): *Array‹[EnvironEntry](#classesenvironentrymd)›*
+▸ **all**(): *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
 
-*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L908)*
+*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L908)*
 
  Return all environment variables
 
-**Returns:** *Array‹[EnvironEntry](#classesenvironentrymd)›*
+**Returns:** *Array‹[EnvironEntry](#classes_assembly_as_wasi_environentrymd)›*
 
 ___
 
@@ -1262,7 +943,7 @@ ___
 
 ▸ **get**(`key`: string): *string | null*
 
-*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L916)*
+*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L916)*
 
 Return the value for an environment variable
 
@@ -1275,9 +956,9 @@ Name | Type | Description |
 **Returns:** *string | null*
 
 
-<a name="classesenvironentrymd"></a>
+<a name="classes_assembly_as_wasi_environentrymd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [EnvironEntry](#classesenvironentrymd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [EnvironEntry](#classes_assembly_as_wasi_environentrymd)
 
 ## Class: EnvironEntry
 
@@ -1300,9 +981,9 @@ Name | Type | Description |
 
 ####  constructor
 
-\+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classesenvironentrymd)*
+\+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classes_assembly_as_wasi_environentrymd)*
 
-*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L872)*
+*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L872)*
 
 **Parameters:**
 
@@ -1311,7 +992,7 @@ Name | Type |
 `key` | string |
 `value` | string |
 
-**Returns:** *[EnvironEntry](#classesenvironentrymd)*
+**Returns:** *[EnvironEntry](#classes_assembly_as_wasi_environentrymd)*
 
 ### Properties
 
@@ -1319,7 +1000,7 @@ Name | Type |
 
 • **key**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L873)*
 
 ___
 
@@ -1327,343 +1008,95 @@ ___
 
 • **value**: *string*
 
-*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L873)*
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L873)*
 
 
-<a name="classeseventmd"></a>
+<a name="classes_assembly_as_wasi_filestatmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [event](#classeseventmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [FileStat](#classes_assembly_as_wasi_filestatmd)
 
-## Class: event
+## Class: FileStat
 
-An event that occurred.
-
-### Hierarchy
-
-* [$event](#classes_eventmd)
-
-  ↳ **event**
-
-### Index
-
-#### Properties
-
-* [__padding1](#private-__padding1)
-* [__padding2](#private-__padding2)
-* [error](#error)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding1
-
-• **__padding1**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:975
-
-___
-
-#### `Private` __padding2
-
-• **__padding2**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:976
-
-___
-
-####  error
-
-• **error**: *[errno](#moduleserrnomd)*
-
-*Inherited from [$event](#classes_eventmd).[error](#error)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
-
-If non-zero, an error that occurred while processing the subscription request.
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-*Inherited from [$event](#classes_eventmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
-
-The type of the event that occurred.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-*Inherited from [$event](#classes_eventmd).[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
-
-User-provided value that got attached to `subscription#userdata`.
-
-
-<a name="classesevent_fd_readwritemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [event_fd_readwrite](#classesevent_fd_readwritemd)
-
-## Class: event_fd_readwrite
-
-An event that occurred when type is `eventtype.FD_READ` or `eventtype.FD_WRITE`.
+Portable information about a file
 
 ### Hierarchy
 
-* [$event](#classes_eventmd)
-
-  ↳ **event_fd_readwrite**
+* **FileStat**
 
 ### Index
 
-#### Properties
+#### Constructors
 
-* [__padding1](#private-__padding1)
-* [error](#error)
-* [flags](#flags)
-* [nbytes](#nbytes)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding1
-
-• **__padding1**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:986
-
-___
-
-####  error
-
-• **error**: *[errno](#moduleserrnomd)*
-
-*Inherited from [$event](#classes_eventmd).[error](#error)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
-
-If non-zero, an error that occurred while processing the subscription request.
-
-___
-
-####  flags
-
-• **flags**: *[eventrwflags](#moduleseventrwflagsmd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:984
-
-___
-
-####  nbytes
-
-• **nbytes**: *[filesize](#filesize)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:982
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-*Inherited from [$event](#classes_eventmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
-
-The type of the event that occurred.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-*Inherited from [$event](#classes_eventmd).[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
-
-User-provided value that got attached to `subscription#userdata`.
-
-
-<a name="classesfdstatmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fdstat](#classesfdstatmd)
-
-## Class: fdstat
-
-File descriptor attributes.
-
-### Hierarchy
-
-* **fdstat**
-
-### Index
+* [constructor](#constructor)
 
 #### Properties
 
-* [filetype](#filetype)
-* [flags](#flags)
-* [rights_base](#rights_base)
-* [rights_inheriting](#rights_inheriting)
+* [access_time](#access_time)
+* [creation_time](#creation_time)
+* [file_size](#file_size)
+* [file_type](#file_type)
+* [modification_time](#modification_time)
+
+### Constructors
+
+####  constructor
+
+\+ **new FileStat**(`st_buf`: usize): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
+
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L75)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`st_buf` | usize |
+
+**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
 ### Properties
 
-####  filetype
+####  access_time
 
-• **filetype**: *[filetype](#filetype)*
+• **access_time**: *f64*
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1049
-
-File type.
+*Defined in [assembly/as-wasi.ts:73](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L73)*
 
 ___
 
-####  flags
+####  creation_time
 
-• **flags**: *[fdflags](#modulesfdflagsmd)*
+• **creation_time**: *f64*
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1051
-
-File descriptor flags.
+*Defined in [assembly/as-wasi.ts:75](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L75)*
 
 ___
 
-####  rights_base
+####  file_size
 
-• **rights_base**: *[rights](#modulesrightsmd)*
+• **file_size**: *filesize*
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1053
-
-Rights that apply to this file descriptor.
+*Defined in [assembly/as-wasi.ts:72](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L72)*
 
 ___
 
-####  rights_inheriting
+####  file_type
 
-• **rights_inheriting**: *[rights](#modulesrightsmd)*
+• **file_type**: *filetype*
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1055
-
-Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through `path_open`.
-
-
-<a name="classesfilestatmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [filestat](#classesfilestatmd)
-
-## Class: filestat
-
-File attributes.
-
-### Hierarchy
-
-* **filestat**
-
-### Index
-
-#### Properties
-
-* [atim](#atim)
-* [ctim](#ctim)
-* [dev](#dev)
-* [filetype](#filetype)
-* [ino](#ino)
-* [mtim](#mtim)
-* [nlink](#nlink)
-* [size](#size)
-
-### Properties
-
-####  atim
-
-• **atim**: *[timestamp](#timestamp)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1077
-
-Last data access timestamp.
+*Defined in [assembly/as-wasi.ts:71](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L71)*
 
 ___
 
-####  ctim
+####  modification_time
 
-• **ctim**: *[timestamp](#timestamp)*
+• **modification_time**: *f64*
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1081
-
-Last file status change timestamp.
-
-___
-
-####  dev
-
-• **dev**: *[device](#device)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1067
-
-Device ID of device containing the file.
-
-___
-
-####  filetype
-
-• **filetype**: *[filetype](#filetype)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1071
-
-File type.
-
-___
-
-####  ino
-
-• **ino**: *[inode](#inode)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1069
-
-File serial number.
-
-___
-
-####  mtim
-
-• **mtim**: *[timestamp](#timestamp)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1079
-
-Last data modification timestamp.
-
-___
-
-####  nlink
-
-• **nlink**: *[linkcount](#linkcount)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1073
-
-Number of hard links to the file.
-
-___
-
-####  size
-
-• **size**: *[filesize](#filesize)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1075
-
-For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+*Defined in [assembly/as-wasi.ts:74](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L74)*
 
 
-<a name="classesfilesystemmd"></a>
+<a name="classes_assembly_as_wasi_filesystemmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [FileSystem](#classesfilesystemmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [FileSystem](#classes_assembly_as_wasi_filesystemmd)
 
 ## Class: FileSystem
 
@@ -1696,7 +1129,7 @@ A class to access a filesystem
 
 ▸ **dirfdForPath**(`path`: string): *fd*
 
-*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L769)*
+*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L769)*
 
 **Parameters:**
 
@@ -1712,7 +1145,7 @@ ___
 
 ▸ **exists**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L533)*
+*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L533)*
 
 Check if a file exists at a given path
 
@@ -1734,7 +1167,7 @@ ___
 
 ▸ **link**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L556)*
+*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L556)*
 
 Create a hard link
 
@@ -1757,9 +1190,9 @@ ___
 
 #### `Static` lstat
 
-▸ **lstat**(`path`: string): *[FileStat](#classesfilestatmd)*
+▸ **lstat**(`path`: string): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
-*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L672)*
+*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L672)*
 
 Retrieve information about a file or a symbolic link
 
@@ -1771,7 +1204,7 @@ Name | Type |
 ------ | ------ |
 `path` | string |
 
-**Returns:** *[FileStat](#classesfilestatmd)*
+**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
 a `FileStat` object
 
@@ -1781,7 +1214,7 @@ ___
 
 ▸ **mkdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L516)*
+*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L516)*
 
 Create a new directory
 
@@ -1801,9 +1234,9 @@ ___
 
 #### `Static` open
 
-▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classesdescriptormd) | null*
+▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classes_assembly_as_wasi_descriptormd) | null*
 
-*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L449)*
+*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L449)*
 
 Open a path
 
@@ -1818,7 +1251,7 @@ Name | Type | Default |
 `path` | string | - |
 `flags` | string | "r" |
 
-**Returns:** *[Descriptor](#classesdescriptormd) | null*
+**Returns:** *[Descriptor](#classes_assembly_as_wasi_descriptormd) | null*
 
 a descriptor
 
@@ -1828,7 +1261,7 @@ ___
 
 ▸ **readdir**(`path`: string): *Array‹string› | null*
 
-*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L726)*
+*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L726)*
 
 Get the content of a directory
 
@@ -1848,7 +1281,7 @@ ___
 
 ▸ **rename**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L698)*
+*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L698)*
 
 Rename a file
 
@@ -1873,7 +1306,7 @@ ___
 
 ▸ **rmdir**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L630)*
+*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L630)*
 
 Remove a directory
 
@@ -1893,9 +1326,9 @@ ___
 
 #### `Static` stat
 
-▸ **stat**(`path`: string): *[FileStat](#classesfilestatmd)*
+▸ **stat**(`path`: string): *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
-*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L647)*
+*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L647)*
 
 Retrieve information about a file
 
@@ -1907,7 +1340,7 @@ Name | Type |
 ------ | ------ |
 `path` | string |
 
-**Returns:** *[FileStat](#classesfilestatmd)*
+**Returns:** *[FileStat](#classes_assembly_as_wasi_filestatmd)*
 
 a `FileStat` object
 
@@ -1917,7 +1350,7 @@ ___
 
 ▸ **symlink**(`old_path`: string, `new_path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L587)*
+*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L587)*
 
 Create a symbolic link
 
@@ -1942,7 +1375,7 @@ ___
 
 ▸ **unlink**(`path`: string): *bool*
 
-*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L613)*
+*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L613)*
 
 Unlink a file
 
@@ -1959,49 +1392,9 @@ Name | Type |
 `true` on success, `false` on failure
 
 
-<a name="classesiovecmd"></a>
+<a name="classes_assembly_as_wasi_performancemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [iovec](#classesiovecmd)
-
-## Class: iovec
-
-A region of memory for scatter/gather reads.
-
-### Hierarchy
-
-* **iovec**
-
-### Index
-
-#### Properties
-
-* [buf](#buf)
-* [buf_len](#buf_len)
-
-### Properties
-
-####  buf
-
-• **buf**: *usize*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1148
-
-The address of the buffer to be filled.
-
-___
-
-####  buf_len
-
-• **buf_len**: *usize*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1150
-
-The length of the buffer to be filled.
-
-
-<a name="classesperformancemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Performance](#classesperformancemd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Performance](#classes_assembly_as_wasi_performancemd)
 
 ## Class: Performance
 
@@ -2021,94 +1414,14 @@ The length of the buffer to be filled.
 
 ▸ **now**(): *f64*
 
-*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L852)*
+*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L852)*
 
 **Returns:** *f64*
 
 
-<a name="classesprestatmd"></a>
+<a name="classes_assembly_as_wasi_processmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [prestat](#classesprestatmd)
-
-## Class: prestat
-
-### Hierarchy
-
-* [$prestat](#classes_prestatmd)
-
-  ↳ **prestat**
-
-### Index
-
-#### Properties
-
-* [__padding0](#private-__padding0)
-* [type](#type)
-
-### Properties
-
-#### `Private` __padding0
-
-• **__padding0**: *usize*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1202
-
-___
-
-####  type
-
-• **type**: *[preopentype](#modulespreopentypemd)*
-
-*Inherited from [$prestat](#classes_prestatmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
-
-
-<a name="classesprestat_dirmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [prestat_dir](#classesprestat_dirmd)
-
-## Class: prestat_dir
-
-The contents of a $prestat when type is `preopentype.DIR`.
-
-### Hierarchy
-
-* [$prestat](#classes_prestatmd)
-
-  ↳ **prestat_dir**
-
-### Index
-
-#### Properties
-
-* [name_len](#name_len)
-* [type](#type)
-
-### Properties
-
-####  name_len
-
-• **name_len**: *usize*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1208
-
-The length of the directory name for use with `fd_prestat_dir_name`.
-
-___
-
-####  type
-
-• **type**: *[preopentype](#modulespreopentypemd)*
-
-*Inherited from [$prestat](#classes_prestatmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
-
-
-<a name="classesprocessmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Process](#classesprocessmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Process](#classes_assembly_as_wasi_processmd)
 
 ## Class: Process
 
@@ -2128,7 +1441,7 @@ Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_previ
 
 ▸ **exit**(`status`: u32): *void*
 
-*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L867)*
+*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L867)*
 
 Cleanly terminate the current process
 
@@ -2141,9 +1454,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classesrandommd"></a>
+<a name="classes_assembly_as_wasi_randommd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Random](#classesrandommd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Random](#classes_assembly_as_wasi_randommd)
 
 ## Class: Random
 
@@ -2164,7 +1477,7 @@ Name | Type | Description |
 
 ▸ **randomBytes**(`len`: usize): *Uint8Array*
 
-*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L831)*
+*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L831)*
 
 Return an array of random bytes
 
@@ -2182,7 +1495,7 @@ ___
 
 ▸ **randomFill**(`buffer`: ArrayBuffer): *void*
 
-*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L814)*
+*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L814)*
 
 Fill a buffer with random data
 
@@ -2195,9 +1508,9 @@ Name | Type | Description |
 **Returns:** *void*
 
 
-<a name="classesstringutilsmd"></a>
+<a name="classes_assembly_as_wasi_stringutilsmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [StringUtils](#classesstringutilsmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [StringUtils](#classes_assembly_as_wasi_stringutilsmd)
 
 ## Class: StringUtils
 
@@ -2217,7 +1530,7 @@ Name | Type | Description |
 
 ▸ **fromCString**(`cstring`: usize): *string*
 
-*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L1023)*
+*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L1023)*
 
 Returns a native string from a zero-terminated C string
 
@@ -2232,270 +1545,9 @@ Name | Type |
 native string
 
 
-<a name="classessubscriptionmd"></a>
+<a name="classes_assembly_as_wasi_timemd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription](#classessubscriptionmd)
-
-## Class: subscription
-
-Subscription to an event.
-
-### Hierarchy
-
-* [$subscription](#classes_subscriptionmd)
-
-  ↳ **subscription**
-
-### Index
-
-#### Properties
-
-* [__padding1](#private-__padding1)
-* [__padding2](#private-__padding2)
-* [__padding3](#private-__padding3)
-* [__padding4](#private-__padding4)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding1
-
-• **__padding1**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1514
-
-___
-
-#### `Private` __padding2
-
-• **__padding2**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1515
-
-___
-
-#### `Private` __padding3
-
-• **__padding3**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1516
-
-___
-
-#### `Private` __padding4
-
-• **__padding4**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1517
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
-
-The type of the event to which to subscribe.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
-
-User-provided value that is attached to the subscription.
-
-
-<a name="classessubscription_clockmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription_clock](#classessubscription_clockmd)
-
-## Class: subscription_clock
-
-### Hierarchy
-
-* [$subscription](#classes_subscriptionmd)
-
-  ↳ **subscription_clock**
-
-### Index
-
-#### Properties
-
-* [__padding1](#private-__padding1)
-* [clock_id](#clock_id)
-* [flags](#flags)
-* [precision](#precision)
-* [timeout](#timeout)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding1
-
-• **__padding1**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1531
-
-___
-
-####  clock_id
-
-• **clock_id**: *[clockid](#modulesclockidmd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1523
-
-The clock against which to compare the timestamp.
-
-___
-
-####  flags
-
-• **flags**: *[subclockflags](#modulessubclockflagsmd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1529
-
-Flags specifying whether the timeout is absolute or relative.
-
-___
-
-####  precision
-
-• **precision**: *[timestamp](#timestamp)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1527
-
-The amount of time that the implementation may wait additionally to coalesce with other events.
-
-___
-
-####  timeout
-
-• **timeout**: *[timestamp](#timestamp)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1525
-
-The absolute or relative timestamp.
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
-
-The type of the event to which to subscribe.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
-
-User-provided value that is attached to the subscription.
-
-
-<a name="classessubscription_fd_readwritemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
-
-## Class: subscription_fd_readwrite
-
-### Hierarchy
-
-* [$subscription](#classes_subscriptionmd)
-
-  ↳ **subscription_fd_readwrite**
-
-### Index
-
-#### Properties
-
-* [__padding1](#private-__padding1)
-* [__padding2](#private-__padding2)
-* [__padding3](#private-__padding3)
-* [file_descriptor](#file_descriptor)
-* [type](#type)
-* [userdata](#userdata)
-
-### Properties
-
-#### `Private` __padding1
-
-• **__padding1**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1539
-
-___
-
-#### `Private` __padding2
-
-• **__padding2**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1540
-
-___
-
-#### `Private` __padding3
-
-• **__padding3**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1541
-
-___
-
-####  file_descriptor
-
-• **file_descriptor**: *fd*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1537
-
-The file descriptor on which to wait for it to become ready for reading or writing.
-
-___
-
-####  type
-
-• **type**: *[eventtype](#moduleseventtypemd)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
-
-The type of the event to which to subscribe.
-
-___
-
-####  userdata
-
-• **userdata**: *[userdata](#userdata)*
-
-*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
-
-User-provided value that is attached to the subscription.
-
-
-<a name="classestimemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Time](#classestimemd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [Time](#classes_assembly_as_wasi_timemd)
 
 ## Class: Time
 
@@ -2521,7 +1573,7 @@ User-provided value that is attached to the subscription.
 
 ▪ **MILLISECOND**: *i32* = Time.NANOSECOND * 1000000
 
-*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L978)*
+*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L978)*
 
 ___
 
@@ -2529,7 +1581,7 @@ ___
 
 ▪ **NANOSECOND**: *i32* = 1
 
-*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L977)*
+*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L977)*
 
 ___
 
@@ -2537,7 +1589,7 @@ ___
 
 ▪ **SECOND**: *i32* = Time.MILLISECOND * 1000
 
-*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L979)*
+*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L979)*
 
 ### Methods
 
@@ -2545,7 +1597,7 @@ ___
 
 ▸ **sleep**(`nanoseconds`: i32): *void*
 
-*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L983)*
+*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L983)*
 
 **Parameters:**
 
@@ -2556,9 +1608,9 @@ Name | Type |
 **Returns:** *void*
 
 
-<a name="classeswasierrormd"></a>
+<a name="classes_assembly_as_wasi_wasierrormd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [WASIError](#classeswasierrormd)
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md) › [WASIError](#classes_assembly_as_wasi_wasierrormd)
 
 ## Class: WASIError
 
@@ -2590,11 +1642,11 @@ A WASI error
 
 ####  constructor
 
-\+ **new WASIError**(`message`: string): *[WASIError](#classeswasierrormd)*
+\+ **new WASIError**(`message`: string): *[WASIError](#classes_assembly_as_wasi_wasierrormd)*
 
 *Overrides void*
 
-*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L60)*
+*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L60)*
 
 **Parameters:**
 
@@ -2602,7 +1654,7 @@ Name | Type | Default |
 ------ | ------ | ------ |
 `message` | string | "" |
 
-**Returns:** *[WASIError](#classeswasierrormd)*
+**Returns:** *[WASIError](#classes_assembly_as_wasi_wasierrormd)*
 
 ### Properties
 
@@ -2610,7 +1662,7 @@ Name | Type | Default |
 
 • **message**: *string*
 
-*Inherited from [WASIError](#classeswasierrormd).[message](#message)*
+*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[message](#message)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1578
 
@@ -2622,7 +1674,7 @@ ___
 
 • **name**: *string*
 
-*Inherited from [WASIError](#classeswasierrormd).[name](#name)*
+*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[name](#name)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1575
 
@@ -2634,7 +1686,7 @@ ___
 
 • **stack**? : *undefined | string*
 
-*Inherited from [WASIError](#classeswasierrormd).[stack](#optional-stack)*
+*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[stack](#optional-stack)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1581
 
@@ -2646,7 +1698,7 @@ Stack trace.
 
 ▸ **toString**(): *string*
 
-*Inherited from [WASIError](#classeswasierrormd).[toString](#tostring)*
+*Inherited from [WASIError](#classes_assembly_as_wasi_wasierrormd).[toString](#tostring)*
 
 Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1587
 
@@ -2657,1177 +1709,68 @@ Method returns a string representing the specified Error class.
 
 <a name="globalsmd"></a>
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd)
+[as-wasi](#readmemd) › [Globals](#globalsmd)
 
-# assemblyscript
+# as-wasi
 
 ## Index
 
-### Namespaces
+### Modules
 
-* [advice](#modulesadvicemd)
-* [clockid](#modulesclockidmd)
-* [errno](#moduleserrnomd)
-* [eventrwflags](#moduleseventrwflagsmd)
-* [eventtype](#moduleseventtypemd)
-* [fdflags](#modulesfdflagsmd)
-* [filetype](#modulesfiletypemd)
-* [fstflags](#modulesfstflagsmd)
-* [lookupflags](#moduleslookupflagsmd)
-* [oflags](#modulesoflagsmd)
-* [preopentype](#modulespreopentypemd)
-* [riflags](#modulesriflagsmd)
-* [rights](#modulesrightsmd)
-* [roflags](#modulesroflagsmd)
-* [sdflags](#modulessdflagsmd)
-* [siflags](#modulessiflagsmd)
-* [signal](#modulessignalmd)
-* [subclockflags](#modulessubclockflagsmd)
-* [whence](#moduleswhencemd)
+* ["assembly/as-wasi"](#modules_assembly_as_wasi_md)
+* ["assembly/index"](#modules_assembly_index_md)
 
-### Classes
+# Modules
 
-* [$event](#classes_eventmd)
-* [$prestat](#classes_prestatmd)
-* [$subscription](#classes_subscriptionmd)
-* [CommandLine](#classescommandlinemd)
-* [Console](#classesconsolemd)
-* [Date](#classesdatemd)
-* [Descriptor](#classesdescriptormd)
-* [Environ](#classesenvironmd)
-* [EnvironEntry](#classesenvironentrymd)
-* [FileStat](#classesfilestatmd)
-* [FileSystem](#classesfilesystemmd)
-* [Performance](#classesperformancemd)
-* [Process](#classesprocessmd)
-* [Random](#classesrandommd)
-* [StringUtils](#classesstringutilsmd)
-* [Time](#classestimemd)
-* [WASIError](#classeswasierrormd)
-* [dirent](#classesdirentmd)
-* [event](#classeseventmd)
-* [event_fd_readwrite](#classesevent_fd_readwritemd)
-* [fdstat](#classesfdstatmd)
-* [filestat](#classesfilestatmd)
-* [iovec](#classesiovecmd)
-* [prestat](#classesprestatmd)
-* [prestat_dir](#classesprestat_dirmd)
-* [subscription](#classessubscriptionmd)
-* [subscription_clock](#classessubscription_clockmd)
-* [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
+
+<a name="modules_assembly_as_wasi_md"></a>
+
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/as-wasi"](#modules_assembly_as_wasi_md)
+
+## Module: "assembly/as-wasi"
+
+### Index
+
+#### Classes
+
+* [CommandLine](#classes_assembly_as_wasi_commandlinemd)
+* [Console](#classes_assembly_as_wasi_consolemd)
+* [Date](#classes_assembly_as_wasi_datemd)
+* [Descriptor](#classes_assembly_as_wasi_descriptormd)
+* [Environ](#classes_assembly_as_wasi_environmd)
+* [EnvironEntry](#classes_assembly_as_wasi_environentrymd)
+* [FileStat](#classes_assembly_as_wasi_filestatmd)
+* [FileSystem](#classes_assembly_as_wasi_filesystemmd)
+* [Performance](#classes_assembly_as_wasi_performancemd)
+* [Process](#classes_assembly_as_wasi_processmd)
+* [Random](#classes_assembly_as_wasi_randommd)
+* [StringUtils](#classes_assembly_as_wasi_stringutilsmd)
+* [Time](#classes_assembly_as_wasi_timemd)
+* [WASIError](#classes_assembly_as_wasi_wasierrormd)
+
+#### Type aliases
+
+* [aisize](#aisize)
+
+#### Functions
+
+* [wasi_abort](#wasi_abort)
 
 ### Type aliases
 
-* [aisize](#aisize)
-* [char](#char)
-* [device](#device)
-* [dircookie](#dircookie)
-* [exitcode](#exitcode)
-* [fd](#fd)
-* [filedelta](#filedelta)
-* [filesize](#filesize)
-* [inode](#inode)
-* [linkcount](#linkcount)
-* [ptr](#ptr)
-* [struct](#struct)
-* [timestamp](#timestamp)
-* [userdata](#userdata)
-
-### Functions
-
-* [args_get](#args_get)
-* [args_sizes_get](#args_sizes_get)
-* [clock_res_get](#clock_res_get)
-* [clock_time_get](#clock_time_get)
-* [environ_get](#environ_get)
-* [environ_sizes_get](#environ_sizes_get)
-* [fd_advise](#fd_advise)
-* [fd_allocate](#fd_allocate)
-* [fd_close](#fd_close)
-* [fd_datasync](#fd_datasync)
-* [fd_fdstat_get](#fd_fdstat_get)
-* [fd_fdstat_set_flags](#fd_fdstat_set_flags)
-* [fd_fdstat_set_rights](#fd_fdstat_set_rights)
-* [fd_filestat_get](#fd_filestat_get)
-* [fd_filestat_set_size](#fd_filestat_set_size)
-* [fd_filestat_set_times](#fd_filestat_set_times)
-* [fd_pread](#fd_pread)
-* [fd_prestat_dir_name](#fd_prestat_dir_name)
-* [fd_prestat_get](#fd_prestat_get)
-* [fd_pwrite](#fd_pwrite)
-* [fd_read](#fd_read)
-* [fd_readdir](#fd_readdir)
-* [fd_renumber](#fd_renumber)
-* [fd_seek](#fd_seek)
-* [fd_sync](#fd_sync)
-* [fd_tell](#fd_tell)
-* [fd_write](#fd_write)
-* [path_create_directory](#path_create_directory)
-* [path_filestat_get](#path_filestat_get)
-* [path_filestat_set_times](#path_filestat_set_times)
-* [path_link](#path_link)
-* [path_open](#path_open)
-* [path_readlink](#path_readlink)
-* [path_remove_directory](#path_remove_directory)
-* [path_rename](#path_rename)
-* [path_symlink](#path_symlink)
-* [path_unlink_file](#path_unlink_file)
-* [poll_oneoff](#poll_oneoff)
-* [proc_exit](#proc_exit)
-* [proc_raise](#proc_raise)
-* [random_get](#random_get)
-* [sched_yield](#sched_yield)
-* [sock_recv](#sock_recv)
-* [sock_send](#sock_send)
-* [sock_shutdown](#sock_shutdown)
-* [wasi_abort](#wasi_abort)
-
-## Type aliases
-
-###  aisize
+####  aisize
 
 Ƭ **aisize**: *i32*
 
-*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L55)*
+*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L55)*
 
-___
+### Functions
 
-###  char
-
-Ƭ **char**: *u8*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:7
-
-___
-
-###  device
-
-Ƭ **device**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:631
-
-Identifier for a device containing a file system. Can be used in combination with `inode` to uniquely identify a file or directory in the filesystem.
-
-___
-
-###  dircookie
-
-Ƭ **dircookie**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:634
-
-A reference to the offset of a directory entry. The value 0 signifies the start of the directory.
-
-___
-
-###  exitcode
-
-Ƭ **exitcode**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1016
-
-Exit code generated by a process when exiting.
-
-___
-
-###  fd
-
-Ƭ **fd**: *u32*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1019
-
-A file descriptor number.
-
-___
-
-###  filedelta
-
-Ƭ **filedelta**: *i64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1059
-
-Relative offset within a file.
-
-___
-
-###  filesize
-
-Ƭ **filesize**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1062
-
-Non-negative file size or length of a region within a file.
-
-___
-
-###  inode
-
-Ƭ **inode**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1143
-
-File serial number that is unique within its file system.
-
-___
-
-###  linkcount
-
-Ƭ **linkcount**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1154
-
-Number of hard links to an inode.
-
-___
-
-###  ptr
-
-Ƭ **ptr**: *usize*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:8
-
-___
-
-###  struct
-
-Ƭ **struct**: *T*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:9
-
-___
-
-###  timestamp
-
-Ƭ **timestamp**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1545
-
-Timestamp in nanoseconds.
-
-___
-
-###  userdata
-
-Ƭ **userdata**: *u64*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1548
-
-User-provided value that may be attached to objects that is retained when extracted from the implementation.
-
-## Functions
-
-###  args_get
-
-▸ **args_get**(`argv`: [ptr](#ptr)‹[ptr](#ptr)‹[char](#char)››, `argv_buf`: [ptr](#ptr)‹[char](#char)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:14
-
-Read command-line argument data.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`argv` | [ptr](#ptr)‹[ptr](#ptr)‹[char](#char)›› |
-`argv_buf` | [ptr](#ptr)‹[char](#char)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  args_sizes_get
-
-▸ **args_sizes_get**(`argc`: [ptr](#ptr)‹usize›, `argv_buf_size`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:24
-
-Return command-line argument data sizes.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`argc` | [ptr](#ptr)‹usize› |
-`argv_buf_size` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  clock_res_get
-
-▸ **clock_res_get**(`clock`: [clockid](#modulesclockidmd), `resolution`: [ptr](#ptr)‹[timestamp](#timestamp)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:34
-
-Return the resolution of a clock.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`clock` | [clockid](#modulesclockidmd) |
-`resolution` | [ptr](#ptr)‹[timestamp](#timestamp)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  clock_time_get
-
-▸ **clock_time_get**(`clock`: [clockid](#modulesclockidmd), `precision`: [timestamp](#timestamp), `time`: [ptr](#ptr)‹[timestamp](#timestamp)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:44
-
-Return the time value of a clock.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`clock` | [clockid](#modulesclockidmd) |
-`precision` | [timestamp](#timestamp) |
-`time` | [ptr](#ptr)‹[timestamp](#timestamp)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  environ_get
-
-▸ **environ_get**(`environ`: [ptr](#ptr)‹usize›, `environ_buf`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:56
-
-Read environment variable data.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`environ` | [ptr](#ptr)‹usize› |
-`environ_buf` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  environ_sizes_get
-
-▸ **environ_sizes_get**(`environ_count`: [ptr](#ptr)‹usize›, `environ_buf_size`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:66
-
-Return command-line argument data sizes.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`environ_count` | [ptr](#ptr)‹usize› |
-`environ_buf_size` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_advise
-
-▸ **fd_advise**(`fd`: fd, `offset`: [filesize](#filesize), `len`: [filesize](#filesize), `advice`: advice): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:76
-
-Provide file advisory information on a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`offset` | [filesize](#filesize) |
-`len` | [filesize](#filesize) |
-`advice` | advice |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_allocate
-
-▸ **fd_allocate**(`fd`: fd, `offset`: [filesize](#filesize), `len`: [filesize](#filesize)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:90
-
-Provide file advisory information on a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`offset` | [filesize](#filesize) |
-`len` | [filesize](#filesize) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_close
-
-▸ **fd_close**(`fd`: fd): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:102
-
-Close a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_datasync
-
-▸ **fd_datasync**(`fd`: fd): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:110
-
-Synchronize the data of a file to disk.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_fdstat_get
-
-▸ **fd_fdstat_get**(`fd`: fd, `buf`: [struct](#struct)‹[fdstat](#classesfdstatmd)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:118
-
-Get the attributes of a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`buf` | [struct](#struct)‹[fdstat](#classesfdstatmd)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_fdstat_set_flags
-
-▸ **fd_fdstat_set_flags**(`fd`: fd, `flags`: [fdflags](#modulesfdflagsmd)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:128
-
-Adjust the flags associated with a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`flags` | [fdflags](#modulesfdflagsmd) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_fdstat_set_rights
-
-▸ **fd_fdstat_set_rights**(`fd`: fd, `fs_rights_base`: [rights](#modulesrightsmd), `fs_rights_inheriting`: [rights](#modulesrightsmd)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:138
-
-Adjust the rights associated with a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`fs_rights_base` | [rights](#modulesrightsmd) |
-`fs_rights_inheriting` | [rights](#modulesrightsmd) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_filestat_get
-
-▸ **fd_filestat_get**(`fd`: fd, `buf`: [struct](#struct)‹[filestat](#classesfilestatmd)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:150
-
-Return the attributes of an open file.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`buf` | [struct](#struct)‹[filestat](#classesfilestatmd)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_filestat_set_size
-
-▸ **fd_filestat_set_size**(`fd`: fd, `size`: [filesize](#filesize)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:160
-
-Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`size` | [filesize](#filesize) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_filestat_set_times
-
-▸ **fd_filestat_set_times**(`fd`: fd, `st_atim`: [timestamp](#timestamp), `st_mtim`: [timestamp](#timestamp), `fstflags`: fstflags): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:170
-
-Adjust the timestamps of an open file or directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`st_atim` | [timestamp](#timestamp) |
-`st_mtim` | [timestamp](#timestamp) |
-`fstflags` | fstflags |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_pread
-
-▸ **fd_pread**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `offset`: [filesize](#filesize), `nread`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:184
-
-Read from a file descriptor, without using and updating the file descriptor's offset.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`iovs_len` | usize |
-`offset` | [filesize](#filesize) |
-`nread` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_prestat_dir_name
-
-▸ **fd_prestat_dir_name**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:210
-
-Return a description of the given preopened file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_prestat_get
-
-▸ **fd_prestat_get**(`fd`: fd, `buf`: [struct](#struct)‹[prestat](#classesprestatmd)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:200
-
-Return a description of the given preopened file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`buf` | [struct](#struct)‹[prestat](#classesprestatmd)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_pwrite
-
-▸ **fd_pwrite**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `offset`: [filesize](#filesize), `nwritten`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:222
-
-Write to a file descriptor, without using and updating the file descriptor's offset.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`iovs_len` | usize |
-`offset` | [filesize](#filesize) |
-`nwritten` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_read
-
-▸ **fd_read**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `nread`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:238
-
-Read from a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`iovs_len` | usize |
-`nread` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_readdir
-
-▸ **fd_readdir**(`fd`: fd, `buf`: [ptr](#ptr)‹[struct](#struct)‹[dirent](#classesdirentmd)››, `buf_len`: usize, `cookie`: [dircookie](#dircookie), `buf_used`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:252
-
-Read directory entries from a directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`buf` | [ptr](#ptr)‹[struct](#struct)‹[dirent](#classesdirentmd)›› |
-`buf_len` | usize |
-`cookie` | [dircookie](#dircookie) |
-`buf_used` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_renumber
-
-▸ **fd_renumber**(`from`: fd, `to`: fd): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:268
-
-Atomically replace a file descriptor by renumbering another file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`from` | fd |
-`to` | fd |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_seek
-
-▸ **fd_seek**(`fd`: fd, `offset`: [filedelta](#filedelta), `whence`: whence, `newoffset`: [ptr](#ptr)‹[filesize](#filesize)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:278
-
-Move the offset of a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`offset` | [filedelta](#filedelta) |
-`whence` | whence |
-`newoffset` | [ptr](#ptr)‹[filesize](#filesize)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_sync
-
-▸ **fd_sync**(`fd`: fd): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:292
-
-Synchronize the data and metadata of a file to disk.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_tell
-
-▸ **fd_tell**(`fd`: fd, `newoffset`: [ptr](#ptr)‹[filesize](#filesize)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:300
-
-Return the current offset of a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`newoffset` | [ptr](#ptr)‹[filesize](#filesize)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  fd_write
-
-▸ **fd_write**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `nwritten`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:310
-
-Write to a file descriptor.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`iovs_len` | usize |
-`nwritten` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_create_directory
-
-▸ **path_create_directory**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:324
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_filestat_get
-
-▸ **path_filestat_get**(`fd`: fd, `flags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `buf`: [struct](#struct)‹[filestat](#classesfilestatmd)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:336
-
-Return the attributes of a file or directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`flags` | [lookupflags](#moduleslookupflagsmd) |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-`buf` | [struct](#struct)‹[filestat](#classesfilestatmd)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_filestat_set_times
-
-▸ **path_filestat_set_times**(`fd`: fd, `flags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `st_atim`: [timestamp](#timestamp), `st_mtim`: [timestamp](#timestamp), `fstflags`: fstflags): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:352
-
-Adjust the timestamps of a file or directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`flags` | [lookupflags](#moduleslookupflagsmd) |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-`st_atim` | [timestamp](#timestamp) |
-`st_mtim` | [timestamp](#timestamp) |
-`fstflags` | fstflags |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_link
-
-▸ **path_link**(`old_fd`: fd, `old_flags`: [lookupflags](#moduleslookupflagsmd), `old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `new_fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:372
-
-Create a hard link.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`old_fd` | fd |
-`old_flags` | [lookupflags](#moduleslookupflagsmd) |
-`old_path` | [ptr](#ptr)‹[char](#char)› |
-`old_path_len` | usize |
-`new_fd` | fd |
-`new_path` | [ptr](#ptr)‹[char](#char)› |
-`new_path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_open
-
-▸ **path_open**(`dirfd`: fd, `dirflags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `oflags`: oflags, `fs_rights_base`: [rights](#modulesrightsmd), `fs_rights_inheriting`: [rights](#modulesrightsmd), `fs_flags`: [fdflags](#modulesfdflagsmd), `fd`: [ptr](#ptr)‹fd›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:392
-
-Open a file or directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`dirfd` | fd |
-`dirflags` | [lookupflags](#moduleslookupflagsmd) |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-`oflags` | oflags |
-`fs_rights_base` | [rights](#modulesrightsmd) |
-`fs_rights_inheriting` | [rights](#modulesrightsmd) |
-`fs_flags` | [fdflags](#modulesfdflagsmd) |
-`fd` | [ptr](#ptr)‹fd› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_readlink
-
-▸ **path_readlink**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `buf`: [ptr](#ptr)‹[char](#char)›, `buf_len`: usize, `buf_used`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:416
-
-Read the contents of a symbolic link.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-`buf` | [ptr](#ptr)‹[char](#char)› |
-`buf_len` | usize |
-`buf_used` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_remove_directory
-
-▸ **path_remove_directory**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:434
-
-Remove a directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_rename
-
-▸ **path_rename**(`old_fd`: fd, `old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `new_fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:446
-
-Rename a file or directory.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`old_fd` | fd |
-`old_path` | [ptr](#ptr)‹[char](#char)› |
-`old_path_len` | usize |
-`new_fd` | fd |
-`new_path` | [ptr](#ptr)‹[char](#char)› |
-`new_path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_symlink
-
-▸ **path_symlink**(`old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:464
-
-Create a symbolic link.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`old_path` | [ptr](#ptr)‹[char](#char)› |
-`old_path_len` | usize |
-`fd` | fd |
-`new_path` | [ptr](#ptr)‹[char](#char)› |
-`new_path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  path_unlink_file
-
-▸ **path_unlink_file**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:480
-
-Unlink a file.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`fd` | fd |
-`path` | [ptr](#ptr)‹[char](#char)› |
-`path_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  poll_oneoff
-
-▸ **poll_oneoff**(`in_`: [ptr](#ptr)‹[struct](#struct)‹[subscription](#classessubscriptionmd)››, `out`: [ptr](#ptr)‹[struct](#struct)‹[event](#classeseventmd)››, `nsubscriptions`: usize, `nevents`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:492
-
-Concurrently poll for the occurrence of a set of events.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`in_` | [ptr](#ptr)‹[struct](#struct)‹[subscription](#classessubscriptionmd)›› |
-`out` | [ptr](#ptr)‹[struct](#struct)‹[event](#classeseventmd)›› |
-`nsubscriptions` | usize |
-`nevents` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  proc_exit
-
-▸ **proc_exit**(`rval`: u32): *void*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:506
-
-Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`rval` | u32 |
-
-**Returns:** *void*
-
-___
-
-###  proc_raise
-
-▸ **proc_raise**(`sig`: [signal](#modulessignalmd)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:514
-
-Send a signal to the process of the calling thread.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`sig` | [signal](#modulessignalmd) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  random_get
-
-▸ **random_get**(`buf`: usize, `buf_len`: usize): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:522
-
-Write high-quality random data into a buffer.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`buf` | usize |
-`buf_len` | usize |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  sched_yield
-
-▸ **sched_yield**(): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:532
-
-Temporarily yield execution of the calling thread.
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  sock_recv
-
-▸ **sock_recv**(`sock`: fd, `ri_data`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `ri_data_len`: usize, `ri_flags`: [riflags](#modulesriflagsmd), `ro_datalen`: [ptr](#ptr)‹usize›, `ro_flags`: [ptr](#ptr)‹[roflags](#modulesroflagsmd)›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:537
-
-Receive a message from a socket.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`sock` | fd |
-`ri_data` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`ri_data_len` | usize |
-`ri_flags` | [riflags](#modulesriflagsmd) |
-`ro_datalen` | [ptr](#ptr)‹usize› |
-`ro_flags` | [ptr](#ptr)‹[roflags](#modulesroflagsmd)› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  sock_send
-
-▸ **sock_send**(`sock`: fd, `si_data`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `si_data_len`: usize, `si_flags`: [siflags](#modulessiflagsmd), `so_datalen`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:555
-
-Send a message on a socket.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`sock` | fd |
-`si_data` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
-`si_data_len` | usize |
-`si_flags` | [siflags](#modulessiflagsmd) |
-`so_datalen` | [ptr](#ptr)‹usize› |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  sock_shutdown
-
-▸ **sock_shutdown**(`sock`: fd, `how`: [sdflags](#modulessdflagsmd)): *[errno](#moduleserrnomd)*
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:571
-
-Shut down socket send and receive channels.
-
-**Parameters:**
-
-Name | Type |
------- | ------ |
-`sock` | fd |
-`how` | [sdflags](#modulessdflagsmd) |
-
-**Returns:** *[errno](#moduleserrnomd)*
-
-___
-
-###  wasi_abort
+####  wasi_abort
 
 ▸ **wasi_abort**(`message`: string, `fileName`: string, `lineNumber`: u32, `columnNumber`: u32): *void*
 
-*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L1034)*
+*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/ee76aa3/assembly/as-wasi.ts#L1034)*
 
 **Parameters:**
 
@@ -3840,2259 +1783,98 @@ Name | Type | Default |
 
 **Returns:** *void*
 
-# Modules
 
+<a name="modules_assembly_index_md"></a>
 
-<a name="modulesadvicemd"></a>
+[as-wasi](#readmemd) › [Globals](#globalsmd) › ["assembly/index"](#modules_assembly_index_md)
 
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [advice](#modulesadvicemd)
-
-## Namespace: advice
-
-File or memory access pattern advisory information.
+## Module: "assembly/index"
 
 ### Index
 
-#### Variables
+#### References
 
-* [DONTNEED](#const-dontneed)
-* [NOREUSE](#const-noreuse)
-* [NORMAL](#const-normal)
-* [RANDOM](#const-random)
-* [SEQUENTIAL](#const-sequential)
-* [WILLNEED](#const-willneed)
+* [CommandLine](#commandline)
+* [Console](#console)
+* [Date](#date)
+* [Descriptor](#descriptor)
+* [Environ](#environ)
+* [EnvironEntry](#environentry)
+* [FileStat](#filestat)
+* [FileSystem](#filesystem)
+* [Process](#process)
+* [Random](#random)
+* [Time](#time)
+* [WASIError](#wasierror)
 
-### Variables
+### References
 
-#### `Const` DONTNEED
+####  CommandLine
 
-• **DONTNEED**: *advice* = 4
+• **CommandLine**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:601
-
-The application expects that it will not access the specified data in the near future.
-
-___
-
-#### `Const` NOREUSE
-
-• **NOREUSE**: *advice* = 5
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:605
-
-The application expects to access the specified data once and then not reuse it thereafter.
-
-___
-
-#### `Const` NORMAL
-
-• **NORMAL**: *advice* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:585
-
-The application has no advice to give on its behavior with respect to the specified data.
-
-___
-
-#### `Const` RANDOM
-
-• **RANDOM**: *advice* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:593
-
-The application expects to access the specified data in a random order.
-
-___
-
-#### `Const` SEQUENTIAL
-
-• **SEQUENTIAL**: *advice* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:589
-
-The application expects to access the specified data sequentially from lower offsets to higher offsets.
-
-___
-
-#### `Const` WILLNEED
-
-• **WILLNEED**: *advice* = 3
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:597
-
-The application expects to access the specified data in the near future.
-
-
-<a name="modulesclockidmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [clockid](#modulesclockidmd)
-
-## Namespace: clockid
-
-Identifiers for clocks.
-
-### Index
-
-#### Variables
-
-* [MONOTONIC](#const-monotonic)
-* [PROCESS_CPUTIME_ID](#const-process_cputime_id)
-* [REALTIME](#const-realtime)
-* [THREAD_CPUTIME_ID](#const-thread_cputime_id)
-
-### Variables
-
-#### `Const` MONOTONIC
-
-• **MONOTONIC**: *[clockid](#modulesclockidmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:618
-
-The store-wide monotonic clock. Absolute value has no meaning.
-
-___
-
-#### `Const` PROCESS_CPUTIME_ID
-
-• **PROCESS_CPUTIME_ID**: *[clockid](#modulesclockidmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:622
-
-The CPU-time clock associated with the current process.
-
-___
-
-#### `Const` REALTIME
-
-• **REALTIME**: *[clockid](#modulesclockidmd)* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:614
-
-The clock measuring real time. Time value zero corresponds with 1970-01-01T00:00:00Z.
-
-___
-
-#### `Const` THREAD_CPUTIME_ID
-
-• **THREAD_CPUTIME_ID**: *[clockid](#modulesclockidmd)* = 3
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:626
-
-The CPU-time clock associated with the current thread.
-
-
-<a name="moduleserrnomd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [errno](#moduleserrnomd)
-
-## Namespace: errno
-
-Error codes returned by functions.
-
-### Index
-
-#### Variables
-
-* [ACCES](#const-acces)
-* [ADDRINUSE](#const-addrinuse)
-* [ADDRNOTAVAIL](#const-addrnotavail)
-* [AFNOSUPPORT](#const-afnosupport)
-* [AGAIN](#const-again)
-* [ALREADY](#const-already)
-* [BADF](#const-badf)
-* [BADMSG](#const-badmsg)
-* [BUSY](#const-busy)
-* [CANCELED](#const-canceled)
-* [CHILD](#const-child)
-* [CONNABORTED](#const-connaborted)
-* [CONNREFUSED](#const-connrefused)
-* [CONNRESET](#const-connreset)
-* [DEADLK](#const-deadlk)
-* [DESTADDRREQ](#const-destaddrreq)
-* [DOM](#const-dom)
-* [DQUOT](#const-dquot)
-* [EXIST](#const-exist)
-* [FAULT](#const-fault)
-* [FBIG](#const-fbig)
-* [HOSTUNREACH](#const-hostunreach)
-* [IDRM](#const-idrm)
-* [ILSEQ](#const-ilseq)
-* [INPROGRESS](#const-inprogress)
-* [INTR](#const-intr)
-* [INVAL](#const-inval)
-* [IO](#const-io)
-* [ISCONN](#const-isconn)
-* [ISDIR](#const-isdir)
-* [LOOP](#const-loop)
-* [MFILE](#const-mfile)
-* [MLINK](#const-mlink)
-* [MSGSIZE](#const-msgsize)
-* [MULTIHOP](#const-multihop)
-* [NAMETOOLONG](#const-nametoolong)
-* [NETDOWN](#const-netdown)
-* [NETRESET](#const-netreset)
-* [NETUNREACH](#const-netunreach)
-* [NFILE](#const-nfile)
-* [NOBUFS](#const-nobufs)
-* [NODEV](#const-nodev)
-* [NOENT](#const-noent)
-* [NOEXEC](#const-noexec)
-* [NOLCK](#const-nolck)
-* [NOLINK](#const-nolink)
-* [NOMEM](#const-nomem)
-* [NOMSG](#const-nomsg)
-* [NOPROTOOPT](#const-noprotoopt)
-* [NOSPC](#const-nospc)
-* [NOSYS](#const-nosys)
-* [NOTCAPABLE](#const-notcapable)
-* [NOTCONN](#const-notconn)
-* [NOTDIR](#const-notdir)
-* [NOTEMPTY](#const-notempty)
-* [NOTRECOVERABLE](#const-notrecoverable)
-* [NOTSOCK](#const-notsock)
-* [NOTSUP](#const-notsup)
-* [NOTTY](#const-notty)
-* [NXIO](#const-nxio)
-* [OVERFLOW](#const-overflow)
-* [OWNERDEAD](#const-ownerdead)
-* [PERM](#const-perm)
-* [PIPE](#const-pipe)
-* [PROTO](#const-proto)
-* [PROTONOSUPPORT](#const-protonosupport)
-* [PROTOTYPE](#const-prototype)
-* [RANGE](#const-range)
-* [ROFS](#const-rofs)
-* [SPIPE](#const-spipe)
-* [SRCH](#const-srch)
-* [STALE](#const-stale)
-* [SUCCESS](#const-success)
-* [TIMEDOUT](#const-timedout)
-* [TOOBIG](#const-toobig)
-* [TXTBSY](#const-txtbsy)
-* [XDEV](#const-xdev)
-
-### Variables
-
-#### `Const` ACCES
-
-• **ACCES**: *[errno](#moduleserrnomd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:662
-
-Permission denied.
-
-___
-
-#### `Const` ADDRINUSE
-
-• **ADDRINUSE**: *[errno](#moduleserrnomd)* = 3
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:666
-
-Address in use.
-
-___
-
-#### `Const` ADDRNOTAVAIL
-
-• **ADDRNOTAVAIL**: *[errno](#moduleserrnomd)* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:670
-
-Address not available.
-
-___
-
-#### `Const` AFNOSUPPORT
-
-• **AFNOSUPPORT**: *[errno](#moduleserrnomd)* = 5
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:674
-
-Address family not supported.
-
-___
-
-#### `Const` AGAIN
-
-• **AGAIN**: *[errno](#moduleserrnomd)* = 6
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:678
-
-Resource unavailable, or operation would block.
-
-___
-
-#### `Const` ALREADY
-
-• **ALREADY**: *[errno](#moduleserrnomd)* = 7
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:682
-
-Connection already in progress.
-
-___
-
-#### `Const` BADF
-
-• **BADF**: *[errno](#moduleserrnomd)* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:686
-
-Bad file descriptor.
-
-___
-
-#### `Const` BADMSG
-
-• **BADMSG**: *[errno](#moduleserrnomd)* = 9
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:690
-
-Bad message.
-
-___
-
-#### `Const` BUSY
-
-• **BUSY**: *[errno](#moduleserrnomd)* = 10
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:694
-
-Device or resource busy.
-
-___
-
-#### `Const` CANCELED
-
-• **CANCELED**: *[errno](#moduleserrnomd)* = 11
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:698
-
-Operation canceled.
-
-___
-
-#### `Const` CHILD
-
-• **CHILD**: *[errno](#moduleserrnomd)* = 12
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:702
-
-No child processes.
-
-___
-
-#### `Const` CONNABORTED
-
-• **CONNABORTED**: *[errno](#moduleserrnomd)* = 13
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:706
-
-Connection aborted.
-
-___
-
-#### `Const` CONNREFUSED
-
-• **CONNREFUSED**: *[errno](#moduleserrnomd)* = 14
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:710
-
-Connection refused.
-
-___
-
-#### `Const` CONNRESET
-
-• **CONNRESET**: *[errno](#moduleserrnomd)* = 15
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:714
-
-Connection reset.
-
-___
-
-#### `Const` DEADLK
-
-• **DEADLK**: *[errno](#moduleserrnomd)* = 16
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:718
-
-Resource deadlock would occur.
-
-___
-
-#### `Const` DESTADDRREQ
-
-• **DESTADDRREQ**: *[errno](#moduleserrnomd)* = 17
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:722
-
-Destination address required.
-
-___
-
-#### `Const` DOM
-
-• **DOM**: *[errno](#moduleserrnomd)* = 18
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:726
-
-Mathematics argument out of domain of function.
-
-___
-
-#### `Const` DQUOT
-
-• **DQUOT**: *[errno](#moduleserrnomd)* = 19
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:730
-
-Reserved.
-
-___
-
-#### `Const` EXIST
-
-• **EXIST**: *[errno](#moduleserrnomd)* = 20
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:734
-
-File exists.
-
-___
-
-#### `Const` FAULT
-
-• **FAULT**: *[errno](#moduleserrnomd)* = 21
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:738
-
-Bad address.
-
-___
-
-#### `Const` FBIG
-
-• **FBIG**: *[errno](#moduleserrnomd)* = 22
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:742
-
-File too large.
-
-___
-
-#### `Const` HOSTUNREACH
-
-• **HOSTUNREACH**: *[errno](#moduleserrnomd)* = 23
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:746
-
-Host is unreachable.
-
-___
-
-#### `Const` IDRM
-
-• **IDRM**: *[errno](#moduleserrnomd)* = 24
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:750
-
-Identifier removed.
-
-___
-
-#### `Const` ILSEQ
-
-• **ILSEQ**: *[errno](#moduleserrnomd)* = 25
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:754
-
-Illegal byte sequence.
-
-___
-
-#### `Const` INPROGRESS
-
-• **INPROGRESS**: *[errno](#moduleserrnomd)* = 26
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:758
-
-Operation in progress.
-
-___
-
-#### `Const` INTR
-
-• **INTR**: *[errno](#moduleserrnomd)* = 27
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:762
-
-Interrupted function.
-
-___
-
-#### `Const` INVAL
-
-• **INVAL**: *[errno](#moduleserrnomd)* = 28
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:766
-
-Invalid argument.
-
-___
-
-#### `Const` IO
-
-• **IO**: *[errno](#moduleserrnomd)* = 29
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:770
-
-I/O error.
-
-___
-
-#### `Const` ISCONN
-
-• **ISCONN**: *[errno](#moduleserrnomd)* = 30
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:774
-
-Socket is connected.
-
-___
-
-#### `Const` ISDIR
-
-• **ISDIR**: *[errno](#moduleserrnomd)* = 31
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:778
-
-Is a directory.
-
-___
-
-#### `Const` LOOP
-
-• **LOOP**: *[errno](#moduleserrnomd)* = 32
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:782
-
-Too many levels of symbolic links.
-
-___
-
-#### `Const` MFILE
-
-• **MFILE**: *[errno](#moduleserrnomd)* = 33
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:786
-
-File descriptor value too large.
-
-___
-
-#### `Const` MLINK
-
-• **MLINK**: *[errno](#moduleserrnomd)* = 34
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:790
-
-Too many links.
-
-___
-
-#### `Const` MSGSIZE
-
-• **MSGSIZE**: *[errno](#moduleserrnomd)* = 35
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:794
-
-Message too large.
-
-___
-
-#### `Const` MULTIHOP
-
-• **MULTIHOP**: *[errno](#moduleserrnomd)* = 36
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:798
-
-Reserved.
-
-___
-
-#### `Const` NAMETOOLONG
-
-• **NAMETOOLONG**: *[errno](#moduleserrnomd)* = 37
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:802
-
-Filename too long.
-
-___
-
-#### `Const` NETDOWN
-
-• **NETDOWN**: *[errno](#moduleserrnomd)* = 38
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:806
-
-Network is down.
-
-___
-
-#### `Const` NETRESET
-
-• **NETRESET**: *[errno](#moduleserrnomd)* = 39
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:810
-
-Connection aborted by network.
-
-___
-
-#### `Const` NETUNREACH
-
-• **NETUNREACH**: *[errno](#moduleserrnomd)* = 40
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:814
-
-Network unreachable.
-
-___
-
-#### `Const` NFILE
-
-• **NFILE**: *[errno](#moduleserrnomd)* = 41
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:818
-
-Too many files open in system.
-
-___
-
-#### `Const` NOBUFS
-
-• **NOBUFS**: *[errno](#moduleserrnomd)* = 42
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:822
-
-No buffer space available.
-
-___
-
-#### `Const` NODEV
-
-• **NODEV**: *[errno](#moduleserrnomd)* = 43
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:826
-
-No such device.
-
-___
-
-#### `Const` NOENT
-
-• **NOENT**: *[errno](#moduleserrnomd)* = 44
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:830
-
-No such file or directory.
-
-___
-
-#### `Const` NOEXEC
-
-• **NOEXEC**: *[errno](#moduleserrnomd)* = 45
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:834
-
-Executable file format error.
-
-___
-
-#### `Const` NOLCK
-
-• **NOLCK**: *[errno](#moduleserrnomd)* = 46
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:838
-
-No locks available.
-
-___
-
-#### `Const` NOLINK
-
-• **NOLINK**: *[errno](#moduleserrnomd)* = 47
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:842
-
-Reserved.
-
-___
-
-#### `Const` NOMEM
-
-• **NOMEM**: *[errno](#moduleserrnomd)* = 48
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:846
-
-Not enough space.
-
-___
-
-#### `Const` NOMSG
-
-• **NOMSG**: *[errno](#moduleserrnomd)* = 49
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:850
-
-No message of the desired type.
-
-___
-
-#### `Const` NOPROTOOPT
-
-• **NOPROTOOPT**: *[errno](#moduleserrnomd)* = 50
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:854
-
-Protocol not available.
-
-___
-
-#### `Const` NOSPC
-
-• **NOSPC**: *[errno](#moduleserrnomd)* = 51
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:858
-
-No space left on device.
-
-___
-
-#### `Const` NOSYS
-
-• **NOSYS**: *[errno](#moduleserrnomd)* = 52
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:862
-
-Function not supported.
-
-___
-
-#### `Const` NOTCAPABLE
-
-• **NOTCAPABLE**: *[errno](#moduleserrnomd)* = 76
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:958
-
-Extension: Capabilities insufficient.
-
-___
-
-#### `Const` NOTCONN
-
-• **NOTCONN**: *[errno](#moduleserrnomd)* = 53
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:866
-
-The socket is not connected.
-
-___
-
-#### `Const` NOTDIR
-
-• **NOTDIR**: *[errno](#moduleserrnomd)* = 54
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:870
-
-Not a directory or a symbolic link to a directory.
-
-___
-
-#### `Const` NOTEMPTY
-
-• **NOTEMPTY**: *[errno](#moduleserrnomd)* = 55
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:874
-
-Directory not empty.
-
-___
-
-#### `Const` NOTRECOVERABLE
-
-• **NOTRECOVERABLE**: *[errno](#moduleserrnomd)* = 56
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:878
-
-State not recoverable.
-
-___
-
-#### `Const` NOTSOCK
-
-• **NOTSOCK**: *[errno](#moduleserrnomd)* = 57
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:882
-
-Not a socket.
-
-___
-
-#### `Const` NOTSUP
-
-• **NOTSUP**: *[errno](#moduleserrnomd)* = 58
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:886
-
-Not supported, or operation not supported on socket.
-
-___
-
-#### `Const` NOTTY
-
-• **NOTTY**: *[errno](#moduleserrnomd)* = 59
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:890
-
-Inappropriate I/O control operation.
-
-___
-
-#### `Const` NXIO
-
-• **NXIO**: *[errno](#moduleserrnomd)* = 60
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:894
-
-No such device or address.
-
-___
-
-#### `Const` OVERFLOW
-
-• **OVERFLOW**: *[errno](#moduleserrnomd)* = 61
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:898
-
-Value too large to be stored in data type.
-
-___
-
-#### `Const` OWNERDEAD
-
-• **OWNERDEAD**: *[errno](#moduleserrnomd)* = 62
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:902
-
-Previous owner died.
-
-___
-
-#### `Const` PERM
-
-• **PERM**: *[errno](#moduleserrnomd)* = 63
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:906
-
-Operation not permitted.
-
-___
-
-#### `Const` PIPE
-
-• **PIPE**: *[errno](#moduleserrnomd)* = 64
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:910
-
-Broken pipe.
-
-___
-
-#### `Const` PROTO
-
-• **PROTO**: *[errno](#moduleserrnomd)* = 65
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:914
-
-Protocol error.
-
-___
-
-#### `Const` PROTONOSUPPORT
-
-• **PROTONOSUPPORT**: *[errno](#moduleserrnomd)* = 66
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:918
-
-Protocol not supported.
-
-___
-
-#### `Const` PROTOTYPE
-
-• **PROTOTYPE**: *[errno](#moduleserrnomd)* = 67
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:922
-
-Protocol wrong type for socket.
-
-___
-
-#### `Const` RANGE
-
-• **RANGE**: *[errno](#moduleserrnomd)* = 68
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:926
-
-Result too large.
-
-___
-
-#### `Const` ROFS
-
-• **ROFS**: *[errno](#moduleserrnomd)* = 69
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:930
-
-Read-only file system.
-
-___
-
-#### `Const` SPIPE
-
-• **SPIPE**: *[errno](#moduleserrnomd)* = 70
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:934
-
-Invalid seek.
-
-___
-
-#### `Const` SRCH
-
-• **SRCH**: *[errno](#moduleserrnomd)* = 71
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:938
-
-No such process.
-
-___
-
-#### `Const` STALE
-
-• **STALE**: *[errno](#moduleserrnomd)* = 72
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:942
-
-Reserved.
-
-___
-
-#### `Const` SUCCESS
-
-• **SUCCESS**: *[errno](#moduleserrnomd)* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:654
-
-No error occurred. System call completed successfully.
-
-___
-
-#### `Const` TIMEDOUT
-
-• **TIMEDOUT**: *[errno](#moduleserrnomd)* = 73
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:946
-
-Connection timed out.
-
-___
-
-#### `Const` TOOBIG
-
-• **TOOBIG**: *[errno](#moduleserrnomd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:658
-
-Argument list too long.
-
-___
-
-#### `Const` TXTBSY
-
-• **TXTBSY**: *[errno](#moduleserrnomd)* = 74
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:950
-
-Text file busy.
-
-___
-
-#### `Const` XDEV
-
-• **XDEV**: *[errno](#moduleserrnomd)* = 75
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:954
-
-Cross-device link.
-
-
-<a name="moduleseventrwflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [eventrwflags](#moduleseventrwflagsmd)
-
-## Namespace: eventrwflags
-
-The state of the file descriptor subscribed to with `eventtype.FD_READ` or `eventtype.FD_WRITE`.
-
-### Index
-
-#### Variables
-
-* [HANGUP](#const-hangup)
-
-### Variables
-
-#### `Const` HANGUP
-
-• **HANGUP**: *[eventrwflags](#moduleseventrwflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:994
-
-The peer of this socket has closed or disconnected.
-
-
-<a name="moduleseventtypemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [eventtype](#moduleseventtypemd)
-
-## Namespace: eventtype
-
-Type of a subscription to an event or its occurrence.
-
-### Index
-
-#### Variables
-
-* [CLOCK](#const-clock)
-* [FD_READ](#const-fd_read)
-* [FD_WRITE](#const-fd_write)
-
-### Variables
-
-#### `Const` CLOCK
-
-• **CLOCK**: *[eventtype](#moduleseventtypemd)* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1003
-
-The time value of clock has reached the timestamp.
-
-___
-
-#### `Const` FD_READ
-
-• **FD_READ**: *[eventtype](#moduleseventtypemd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1007
-
-File descriptor has data available for reading.
-
-___
-
-#### `Const` FD_WRITE
-
-• **FD_WRITE**: *[eventtype](#moduleseventtypemd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1011
-
-File descriptor has capacity available for writing
-
-
-<a name="modulesfdflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fdflags](#modulesfdflagsmd)
-
-## Namespace: fdflags
-
-File descriptor flags.
-
-### Index
-
-#### Variables
-
-* [APPEND](#const-append)
-* [DSYNC](#const-dsync)
-* [NONBLOCK](#const-nonblock)
-* [RSYNC](#const-rsync)
-* [SYNC](#const-sync)
-
-### Variables
-
-#### `Const` APPEND
-
-• **APPEND**: *[fdflags](#modulesfdflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1026
-
-Append mode: Data written to the file is always appended to the file's end.
-
-___
-
-#### `Const` DSYNC
-
-• **DSYNC**: *[fdflags](#modulesfdflagsmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1030
-
-Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
-
-___
-
-#### `Const` NONBLOCK
-
-• **NONBLOCK**: *[fdflags](#modulesfdflagsmd)* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1034
-
-Non-blocking mode.
-
-___
-
-#### `Const` RSYNC
-
-• **RSYNC**: *[fdflags](#modulesfdflagsmd)* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1038
-
-Synchronized read I/O operations.
-
-___
-
-#### `Const` SYNC
-
-• **SYNC**: *[fdflags](#modulesfdflagsmd)* = 16
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1042
-
-Write according to synchronized I/O file integrity completion.
-
-
-<a name="modulesfiletypemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [filetype](#modulesfiletypemd)
-
-## Namespace: filetype
-
-The type of a file descriptor or file.
-
-### Index
-
-#### Variables
-
-* [BLOCK_DEVICE](#const-block_device)
-* [CHARACTER_DEVICE](#const-character_device)
-* [DIRECTORY](#const-directory)
-* [REGULAR_FILE](#const-regular_file)
-* [SOCKET_DGRAM](#const-socket_dgram)
-* [SOCKET_STREAM](#const-socket_stream)
-* [SYMBOLIC_LINK](#const-symbolic_link)
-* [UNKNOWN](#const-unknown)
-
-### Variables
-
-#### `Const` BLOCK_DEVICE
-
-• **BLOCK_DEVICE**: *[filetype](#filetype)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1093
-
-The file descriptor or file refers to a block device inode.
-
-___
-
-#### `Const` CHARACTER_DEVICE
-
-• **CHARACTER_DEVICE**: *[filetype](#filetype)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1097
-
-The file descriptor or file refers to a character device inode.
-
-___
-
-#### `Const` DIRECTORY
-
-• **DIRECTORY**: *[filetype](#filetype)* = 3
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1101
-
-The file descriptor or file refers to a directory inode.
-
-___
-
-#### `Const` REGULAR_FILE
-
-• **REGULAR_FILE**: *[filetype](#filetype)* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1105
-
-The file descriptor or file refers to a regular file inode.
-
-___
-
-#### `Const` SOCKET_DGRAM
-
-• **SOCKET_DGRAM**: *[filetype](#filetype)* = 5
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1109
-
-The file descriptor or file refers to a datagram socket.
-
-___
-
-#### `Const` SOCKET_STREAM
-
-• **SOCKET_STREAM**: *[filetype](#filetype)* = 6
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1113
-
-The file descriptor or file refers to a byte-stream socket.
-
-___
-
-#### `Const` SYMBOLIC_LINK
-
-• **SYMBOLIC_LINK**: *[filetype](#filetype)* = 7
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1117
-
-The file refers to a symbolic link inode.
-
-___
-
-#### `Const` UNKNOWN
-
-• **UNKNOWN**: *[filetype](#filetype)* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1089
-
-The type of the file descriptor or file is unknown or is different from any of the other types specified.
-
-
-<a name="modulesfstflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fstflags](#modulesfstflagsmd)
-
-## Namespace: fstflags
-
-Which file time attributes to adjust.
-
-### Index
-
-#### Variables
-
-* [SET_ATIM](#const-set_atim)
-* [SET_ATIM_NOW](#const-set_atim_now)
-* [SET_MTIM](#const-set_mtim)
-* [SET_MTIM_NOW](#const-set_mtim_now)
-
-### Variables
-
-#### `Const` SET_ATIM
-
-• **SET_ATIM**: *fstflags* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1126
-
-Adjust the last data access timestamp to the value stored in `filestat#st_atim`.
-
-___
-
-#### `Const` SET_ATIM_NOW
-
-• **SET_ATIM_NOW**: *fstflags* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1130
-
-Adjust the last data access timestamp to the time of clock `clockid.REALTIME`.
-
-___
-
-#### `Const` SET_MTIM
-
-• **SET_MTIM**: *fstflags* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1134
-
-Adjust the last data modification timestamp to the value stored in `filestat#st_mtim`.
-
-___
-
-#### `Const` SET_MTIM_NOW
-
-• **SET_MTIM_NOW**: *fstflags* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1138
-
-Adjust the last data modification timestamp to the time of clock `clockid.REALTIME`.
-
-
-<a name="moduleslookupflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [lookupflags](#moduleslookupflagsmd)
-
-## Namespace: lookupflags
-
-Flags determining the method of how paths are resolved.
-
-### Index
-
-#### Variables
-
-* [SYMLINK_FOLLOW](#const-symlink_follow)
-
-### Variables
-
-#### `Const` SYMLINK_FOLLOW
-
-• **SYMLINK_FOLLOW**: *[lookupflags](#moduleslookupflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1161
-
-As long as the resolved path corresponds to a symbolic link, it is expanded.
-
-
-<a name="modulesoflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [oflags](#modulesoflagsmd)
-
-## Namespace: oflags
-
-Open flags.
-
-### Index
-
-#### Variables
-
-* [CREAT](#const-creat)
-* [DIRECTORY](#const-directory)
-* [EXCL](#const-excl)
-* [TRUNC](#const-trunc)
-
-### Variables
-
-#### `Const` CREAT
-
-• **CREAT**: *oflags* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1170
-
-Create file if it does not exist.
-
-___
-
-#### `Const` DIRECTORY
-
-• **DIRECTORY**: *oflags* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1174
-
-Fail if not a directory.
-
-___
-
-#### `Const` EXCL
-
-• **EXCL**: *oflags* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1178
-
-Fail if file already exists.
-
-___
-
-#### `Const` TRUNC
-
-• **TRUNC**: *oflags* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1182
-
-Truncate file to size 0.
-
-
-<a name="modulespreopentypemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [preopentype](#modulespreopentypemd)
-
-## Namespace: preopentype
-
-Identifiers for preopened capabilities.
-
-### Index
-
-#### Variables
-
-* [DIR](#const-dir)
-
-### Variables
-
-#### `Const` DIR
-
-• **DIR**: *[preopentype](#modulespreopentypemd)* = 0
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1191
-
-A pre-opened directory.
-
-
-<a name="modulesriflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [riflags](#modulesriflagsmd)
-
-## Namespace: riflags
-
-Flags provided to `sock_recv`.
-
-### Index
-
-#### Variables
-
-* [PEEK](#const-peek)
-* [WAITALL](#const-waitall)
-
-### Variables
-
-#### `Const` PEEK
-
-• **PEEK**: *[riflags](#modulesriflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1216
-
-Returns the message without removing it from the socket's receive queue.
-
-___
-
-#### `Const` WAITALL
-
-• **WAITALL**: *[riflags](#modulesriflagsmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1220
-
-On byte-stream sockets, block until the full amount of data can be returned.
-
-
-<a name="modulesrightsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [rights](#modulesrightsmd)
-
-## Namespace: rights
-
-File descriptor rights, determining which actions may be performed.
-
-### Index
-
-#### Variables
-
-* [FD_ADVISE](#const-fd_advise)
-* [FD_ALLOCATE](#const-fd_allocate)
-* [FD_DATASYNC](#const-fd_datasync)
-* [FD_FDSTAT_SET_FLAGS](#const-fd_fdstat_set_flags)
-* [FD_FILESTAT_GET](#const-fd_filestat_get)
-* [FD_FILESTAT_SET_SIZE](#const-fd_filestat_set_size)
-* [FD_FILESTAT_SET_TIMES](#const-fd_filestat_set_times)
-* [FD_READ](#const-fd_read)
-* [FD_READDIR](#const-fd_readdir)
-* [FD_SEEK](#const-fd_seek)
-* [FD_SYNC](#const-fd_sync)
-* [FD_TELL](#const-fd_tell)
-* [FD_WRITE](#const-fd_write)
-* [PATH_CREATE_DIRECTORY](#const-path_create_directory)
-* [PATH_CREATE_FILE](#const-path_create_file)
-* [PATH_FILESTAT_GET](#const-path_filestat_get)
-* [PATH_FILESTAT_SET_SIZE](#const-path_filestat_set_size)
-* [PATH_FILESTAT_SET_TIMES](#const-path_filestat_set_times)
-* [PATH_LINK_SOURCE](#const-path_link_source)
-* [PATH_LINK_TARGET](#const-path_link_target)
-* [PATH_OPEN](#const-path_open)
-* [PATH_READLINK](#const-path_readlink)
-* [PATH_REMOVE_DIRECTORY](#const-path_remove_directory)
-* [PATH_RENAME_SOURCE](#const-path_rename_source)
-* [PATH_RENAME_TARGET](#const-path_rename_target)
-* [PATH_UNLINK_FILE](#const-path_unlink_file)
-* [POLL_FD_READWRITE](#const-poll_fd_readwrite)
-* [RIGHT_PATH_SYMLINK](#const-right_path_symlink)
-* [SOCK_SHUTDOWN](#const-sock_shutdown)
-
-### Variables
-
-#### `Const` FD_ADVISE
-
-• **FD_ADVISE**: *[rights](#modulesrightsmd)* = 128
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1257
-
-The right to invoke `fd_advise`.
-
-___
-
-#### `Const` FD_ALLOCATE
-
-• **FD_ALLOCATE**: *[rights](#modulesrightsmd)* = 256
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1261
-
-The right to invoke `fd_allocate`.
-
-___
-
-#### `Const` FD_DATASYNC
-
-• **FD_DATASYNC**: *[rights](#modulesrightsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1229
-
-The right to invoke `fd_datasync`.
-
-___
-
-#### `Const` FD_FDSTAT_SET_FLAGS
-
-• **FD_FDSTAT_SET_FLAGS**: *[rights](#modulesrightsmd)* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1241
-
-The right to invoke `fd_fdstat_set_flags`.
-
-___
-
-#### `Const` FD_FILESTAT_GET
-
-• **FD_FILESTAT_GET**: *[rights](#modulesrightsmd)* = 2097152
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1313
-
-The right to invoke `fd_filestat_get`.
-
-___
-
-#### `Const` FD_FILESTAT_SET_SIZE
-
-• **FD_FILESTAT_SET_SIZE**: *[rights](#modulesrightsmd)* = 4194304
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1317
-
-The right to invoke `fd_filestat_set_size`.
-
-___
-
-#### `Const` FD_FILESTAT_SET_TIMES
-
-• **FD_FILESTAT_SET_TIMES**: *[rights](#modulesrightsmd)* = 8388608
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1321
-
-The right to invoke `fd_filestat_set_times`.
-
-___
-
-#### `Const` FD_READ
-
-• **FD_READ**: *[rights](#modulesrightsmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1233
-
-The right to invoke `fd_read` and `sock_recv`.
-
-___
-
-#### `Const` FD_READDIR
-
-• **FD_READDIR**: *[rights](#modulesrightsmd)* = 16384
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1285
-
-The right to invoke `fd_readdir`.
-
-___
-
-#### `Const` FD_SEEK
-
-• **FD_SEEK**: *[rights](#modulesrightsmd)* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1237
-
-The right to invoke `fd_seek`. This flag implies `rights.FD_TELL`.
-
-___
-
-#### `Const` FD_SYNC
-
-• **FD_SYNC**: *[rights](#modulesrightsmd)* = 16
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1245
-
-The right to invoke `fd_sync`.
-
-___
-
-#### `Const` FD_TELL
-
-• **FD_TELL**: *[rights](#modulesrightsmd)* = 32
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1249
-
-The right to invoke `fd_seek` in such a way that the file offset remains unaltered (i.e., `whence.CUR` with offset zero), or to invoke `fd_tell`).
-
-___
-
-#### `Const` FD_WRITE
-
-• **FD_WRITE**: *[rights](#modulesrightsmd)* = 64
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1253
-
-The right to invoke `fd_write` and `sock_send`. If `rights.FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
-
-___
-
-#### `Const` PATH_CREATE_DIRECTORY
-
-• **PATH_CREATE_DIRECTORY**: *[rights](#modulesrightsmd)* = 512
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1265
-
-The right to invoke `path_create_directory`.
-
-___
-
-#### `Const` PATH_CREATE_FILE
-
-• **PATH_CREATE_FILE**: *[rights](#modulesrightsmd)* = 1024
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1269
-
-If `rights.PATH_OPEN` is set, the right to invoke `path_open` with `oflags.CREAT`.
-
-___
-
-#### `Const` PATH_FILESTAT_GET
-
-• **PATH_FILESTAT_GET**: *[rights](#modulesrightsmd)* = 262144
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1301
-
-The right to invoke `path_filestat_get`.
-
-___
-
-#### `Const` PATH_FILESTAT_SET_SIZE
-
-• **PATH_FILESTAT_SET_SIZE**: *[rights](#modulesrightsmd)* = 524288
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1305
-
-The right to change a file's size (there is no `path_filestat_set_size`). If `rights.PATH_OPEN` is set, includes the right to invoke `path_open` with `oflags.TRUNC`.
-
-___
-
-#### `Const` PATH_FILESTAT_SET_TIMES
-
-• **PATH_FILESTAT_SET_TIMES**: *[rights](#modulesrightsmd)* = 1048576
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1309
-
-The right to invoke `path_filestat_set_times`.
-
-___
-
-#### `Const` PATH_LINK_SOURCE
-
-• **PATH_LINK_SOURCE**: *[rights](#modulesrightsmd)* = 2048
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1273
-
-The right to invoke `path_link` with the file descriptor as the source directory.
-
-___
-
-#### `Const` PATH_LINK_TARGET
-
-• **PATH_LINK_TARGET**: *[rights](#modulesrightsmd)* = 4096
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1277
-
-The right to invoke `path_link` with the file descriptor as the target directory.
-
-___
-
-#### `Const` PATH_OPEN
-
-• **PATH_OPEN**: *[rights](#modulesrightsmd)* = 8192
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1281
-
-The right to invoke `path_open`.
-
-___
-
-#### `Const` PATH_READLINK
-
-• **PATH_READLINK**: *[rights](#modulesrightsmd)* = 32768
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1289
-
-The right to invoke `path_readlink`.
-
-___
-
-#### `Const` PATH_REMOVE_DIRECTORY
-
-• **PATH_REMOVE_DIRECTORY**: *[rights](#modulesrightsmd)* = 33554432
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1329
-
-The right to invoke `path_remove_directory`.
-
-___
-
-#### `Const` PATH_RENAME_SOURCE
-
-• **PATH_RENAME_SOURCE**: *[rights](#modulesrightsmd)* = 65536
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1293
-
-The right to invoke `path_rename` with the file descriptor as the source directory.
-
-___
-
-#### `Const` PATH_RENAME_TARGET
-
-• **PATH_RENAME_TARGET**: *[rights](#modulesrightsmd)* = 131072
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1297
-
-The right to invoke `path_rename` with the file descriptor as the target directory.
-
-___
-
-#### `Const` PATH_UNLINK_FILE
-
-• **PATH_UNLINK_FILE**: *[rights](#modulesrightsmd)* = 67108864
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1333
-
-The right to invoke `path_unlink_file`.
-
-___
-
-#### `Const` POLL_FD_READWRITE
-
-• **POLL_FD_READWRITE**: *[rights](#modulesrightsmd)* = 134217728
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1337
-
-If `rights.FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype.FD_READ`. If `rights.FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype.FD_WRITE`.
-
-___
-
-#### `Const` RIGHT_PATH_SYMLINK
-
-• **RIGHT_PATH_SYMLINK**: *[rights](#modulesrightsmd)* = 16777216
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1325
-
-The right to invoke `path_symlink`.
-
-___
-
-#### `Const` SOCK_SHUTDOWN
-
-• **SOCK_SHUTDOWN**: *[rights](#modulesrightsmd)* = 268435456
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1341
-
-The right to invoke `sock_shutdown`.
-
-
-<a name="modulesroflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [roflags](#modulesroflagsmd)
-
-## Namespace: roflags
-
-Flags returned by `sock_recv`.
-
-### Index
-
-#### Variables
-
-* [DATA_TRUNCATED](#const-data_truncated)
-
-### Variables
-
-#### `Const` DATA_TRUNCATED
-
-• **DATA_TRUNCATED**: *[roflags](#modulesroflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1350
-
-Message data has been truncated.
-
-
-<a name="modulessdflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [sdflags](#modulessdflagsmd)
-
-## Namespace: sdflags
-
-Which channels on a socket to shut down.
-
-### Index
-
-#### Variables
-
-* [RD](#const-rd)
-* [WR](#const-wr)
-
-### Variables
-
-#### `Const` RD
-
-• **RD**: *[sdflags](#modulessdflagsmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1359
-
-Disables further receive operations.
-
-___
-
-#### `Const` WR
-
-• **WR**: *[sdflags](#modulessdflagsmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1363
-
-Disables further send operations.
-
-
-<a name="modulessiflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [siflags](#modulessiflagsmd)
-
-## Namespace: siflags
-
-Flags provided to `sock_send`.
-
-
-<a name="modulessignalmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [signal](#modulessignalmd)
-
-## Namespace: signal
-
-Signal condition.
-
-### Index
-
-#### Variables
-
-* [ABRT](#const-abrt)
-* [ALRM](#const-alrm)
-* [BUS](#const-bus)
-* [CHLD](#const-chld)
-* [CONT](#const-cont)
-* [FPE](#const-fpe)
-* [HUP](#const-hup)
-* [ILL](#const-ill)
-* [INT](#const-int)
-* [KILL](#const-kill)
-* [PIPE](#const-pipe)
-* [POLL](#const-poll)
-* [PROF](#const-prof)
-* [PWR](#const-pwr)
-* [QUIT](#const-quit)
-* [SEGV](#const-segv)
-* [STOP](#const-stop)
-* [SYS](#const-sys)
-* [TERM](#const-term)
-* [TRAP](#const-trap)
-* [TSTP](#const-tstp)
-* [TTIN](#const-ttin)
-* [TTOU](#const-ttou)
-* [URG](#const-urg)
-* [USR1](#const-usr1)
-* [USR2](#const-usr2)
-* [VTALRM](#const-vtalrm)
-* [WINCH](#const-winch)
-* [XCPU](#const-xcpu)
-* [XFSZ](#const-xfsz)
-
-### Variables
-
-#### `Const` ABRT
-
-• **ABRT**: *[signal](#modulessignalmd)* = 6
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1398
-
-Process abort signal.
-
-___
-
-#### `Const` ALRM
-
-• **ALRM**: *[signal](#modulessignalmd)* = 14
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1430
-
-Alarm clock.
-
-___
-
-#### `Const` BUS
-
-• **BUS**: *[signal](#modulessignalmd)* = 7
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1402
-
-Access to an undefined portion of a memory object.
-
-___
-
-#### `Const` CHLD
-
-• **CHLD**: *[signal](#modulessignalmd)* = 16
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1438
-
-Child process terminated, stopped, or continued.
-
-___
-
-#### `Const` CONT
-
-• **CONT**: *[signal](#modulessignalmd)* = 17
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1442
-
-Continue executing, if stopped.
-
-___
-
-#### `Const` FPE
-
-• **FPE**: *[signal](#modulessignalmd)* = 8
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1406
-
-Erroneous arithmetic operation.
-
-___
-
-#### `Const` HUP
-
-• **HUP**: *[signal](#modulessignalmd)* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1378
-
-Hangup.
-
-___
-
-#### `Const` ILL
-
-• **ILL**: *[signal](#modulessignalmd)* = 4
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1390
-
-Illegal instruction.
-
-___
-
-#### `Const` INT
-
-• **INT**: *[signal](#modulessignalmd)* = 2
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1382
-
-Terminate interrupt signal.
-
-___
-
-#### `Const` KILL
-
-• **KILL**: *[signal](#modulessignalmd)* = 9
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1410
-
-Kill.
-
-___
-
-#### `Const` PIPE
-
-• **PIPE**: *[signal](#modulessignalmd)* = 13
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1426
-
-Write on a pipe with no one to read it.
-
-___
-
-#### `Const` POLL
-
-• **POLL**: *[signal](#modulessignalmd)* = 28
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1483
-
-___
-
-#### `Const` PROF
-
-• **PROF**: *[signal](#modulessignalmd)* = 26
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1477
-
-___
-
-#### `Const` PWR
-
-• **PWR**: *[signal](#modulessignalmd)* = 29
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1486
-
-___
-
-#### `Const` QUIT
-
-• **QUIT**: *[signal](#modulessignalmd)* = 3
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1386
-
-Terminal quit signal.
-
-___
-
-#### `Const` SEGV
-
-• **SEGV**: *[signal](#modulessignalmd)* = 11
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1418
-
-Invalid memory reference.
-
-___
-
-#### `Const` STOP
-
-• **STOP**: *[signal](#modulessignalmd)* = 18
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1446
-
-Stop executing.
-
-___
-
-#### `Const` SYS
-
-• **SYS**: *[signal](#modulessignalmd)* = 30
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1490
-
-Bad system call.
-
 ___
 
-#### `Const` TERM
+####  Console
 
-• **TERM**: *[signal](#modulessignalmd)* = 15
+• **Console**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1434
-
-Termination signal.
-
-___
-
-#### `Const` TRAP
-
-• **TRAP**: *[signal](#modulessignalmd)* = 5
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1394
-
-Trace/breakpoint trap.
-
-___
-
-#### `Const` TSTP
-
-• **TSTP**: *[signal](#modulessignalmd)* = 19
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1450
-
-Terminal stop signal.
-
-___
-
-#### `Const` TTIN
-
-• **TTIN**: *[signal](#modulessignalmd)* = 20
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1454
-
-Background process attempting read.
-
 ___
 
-#### `Const` TTOU
+####  Date
 
-• **TTOU**: *[signal](#modulessignalmd)* = 21
+• **Date**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1458
-
-Background process attempting write.
-
 ___
-
-#### `Const` URG
-
-• **URG**: *[signal](#modulessignalmd)* = 22
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1462
+####  Descriptor
 
-High bandwidth data is available at a socket.
+• **Descriptor**:
 
 ___
 
-#### `Const` USR1
+####  Environ
 
-• **USR1**: *[signal](#modulessignalmd)* = 10
+• **Environ**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1414
-
-User-defined signal 1.
-
 ___
-
-#### `Const` USR2
-
-• **USR2**: *[signal](#modulessignalmd)* = 12
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1422
+####  EnvironEntry
 
-User-defined signal 2.
+• **EnvironEntry**:
 
 ___
 
-#### `Const` VTALRM
+####  FileStat
 
-• **VTALRM**: *[signal](#modulessignalmd)* = 25
+• **FileStat**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1474
-
-Virtual timer expired.
-
 ___
 
-#### `Const` WINCH
+####  FileSystem
 
-• **WINCH**: *[signal](#modulessignalmd)* = 27
+• **FileSystem**:
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1480
-
 ___
-
-#### `Const` XCPU
 
-• **XCPU**: *[signal](#modulessignalmd)* = 23
+####  Process
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1466
+• **Process**:
 
-CPU time limit exceeded.
-
 ___
-
-#### `Const` XFSZ
-
-• **XFSZ**: *[signal](#modulessignalmd)* = 24
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1470
-
-File size limit exceeded.
-
-
-<a name="modulessubclockflagsmd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subclockflags](#modulessubclockflagsmd)
-
-## Namespace: subclockflags
-
-Flags determining how to interpret the timestamp provided in `subscription_t::u.clock.timeout.
-
-### Index
-
-#### Variables
-
-* [ABSTIME](#const-abstime)
-
-### Variables
-
-#### `Const` ABSTIME
-
-• **ABSTIME**: *[subclockflags](#modulessubclockflagsmd)* = 1
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1499
+####  Random
 
-If set, treat the timestamp provided in `clocksubscription` as an absolute timestamp.
+• **Random**:
 
-
-<a name="moduleswhencemd"></a>
-
-[assemblyscript](#readmemd) › [Globals](#globalsmd) › [whence](#moduleswhencemd)
-
-## Namespace: whence
-
-The position relative to which to set the offset of the file descriptor.
-
-### Index
-
-#### Variables
-
-* [CUR](#const-cur)
-* [END](#const-end)
-* [SET](#const-set)
-
-### Variables
-
-#### `Const` CUR
-
-• **CUR**: *whence* = 1
-
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1559
-
-Seek relative to current position.
-
 ___
-
-#### `Const` END
 
-• **END**: *whence* = 2
+####  Time
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1563
+• **Time**:
 
-Seek relative to end-of-file.
-
 ___
-
-#### `Const` SET
-
-• **SET**: *whence* = 0
 
-Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1555
+####  WASIError
 
-Seek relative to start-of-file.
+• **WASIError**:

--- a/REFERENCE_API_DOCS.md
+++ b/REFERENCE_API_DOCS.md
@@ -1,0 +1,6098 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [assemblyscript](#assemblyscript)
+- [Standard library](#standard-library)
+- [Classes](#classes)
+  - [Class: $event](#class-event)
+    - [Hierarchy](#hierarchy)
+    - [Index](#index)
+    - [Properties](#properties)
+  - [Class: $prestat](#class-prestat)
+    - [Hierarchy](#hierarchy-1)
+    - [Index](#index-1)
+    - [Properties](#properties-1)
+  - [Class: $subscription](#class-subscription)
+    - [Hierarchy](#hierarchy-2)
+    - [Index](#index-2)
+    - [Properties](#properties-2)
+  - [Class: CommandLine](#class-commandline)
+    - [Hierarchy](#hierarchy-3)
+    - [Index](#index-3)
+    - [Constructors](#constructors)
+    - [Properties](#properties-3)
+    - [Methods](#methods)
+  - [Class: Console](#class-console)
+    - [Hierarchy](#hierarchy-4)
+    - [Index](#index-4)
+    - [Methods](#methods-1)
+  - [Class: Date](#class-date)
+    - [Hierarchy](#hierarchy-5)
+    - [Index](#index-5)
+    - [Methods](#methods-2)
+  - [Class: Descriptor](#class-descriptor)
+    - [Hierarchy](#hierarchy-6)
+    - [Index](#index-6)
+    - [Constructors](#constructors-1)
+    - [Accessors](#accessors)
+    - [Methods](#methods-3)
+  - [Class: dirent](#class-dirent)
+    - [Hierarchy](#hierarchy-7)
+    - [Index](#index-7)
+    - [Properties](#properties-4)
+  - [Class: Environ](#class-environ)
+    - [Hierarchy](#hierarchy-8)
+    - [Index](#index-8)
+    - [Constructors](#constructors-2)
+    - [Properties](#properties-5)
+    - [Methods](#methods-4)
+  - [Class: EnvironEntry](#class-environentry)
+    - [Hierarchy](#hierarchy-9)
+    - [Index](#index-9)
+    - [Constructors](#constructors-3)
+    - [Properties](#properties-6)
+  - [Class: event](#class-event)
+    - [Hierarchy](#hierarchy-10)
+    - [Index](#index-10)
+    - [Properties](#properties-7)
+  - [Class: event_fd_readwrite](#class-event_fd_readwrite)
+    - [Hierarchy](#hierarchy-11)
+    - [Index](#index-11)
+    - [Properties](#properties-8)
+  - [Class: fdstat](#class-fdstat)
+    - [Hierarchy](#hierarchy-12)
+    - [Index](#index-12)
+    - [Properties](#properties-9)
+  - [Class: filestat](#class-filestat)
+    - [Hierarchy](#hierarchy-13)
+    - [Index](#index-13)
+    - [Properties](#properties-10)
+  - [Class: FileSystem](#class-filesystem)
+    - [Hierarchy](#hierarchy-14)
+    - [Index](#index-14)
+    - [Methods](#methods-5)
+  - [Class: iovec](#class-iovec)
+    - [Hierarchy](#hierarchy-15)
+    - [Index](#index-15)
+    - [Properties](#properties-11)
+  - [Class: Performance](#class-performance)
+    - [Hierarchy](#hierarchy-16)
+    - [Index](#index-16)
+    - [Methods](#methods-6)
+  - [Class: prestat](#class-prestat)
+    - [Hierarchy](#hierarchy-17)
+    - [Index](#index-17)
+    - [Properties](#properties-12)
+  - [Class: prestat_dir](#class-prestat_dir)
+    - [Hierarchy](#hierarchy-18)
+    - [Index](#index-18)
+    - [Properties](#properties-13)
+  - [Class: Process](#class-process)
+    - [Hierarchy](#hierarchy-19)
+    - [Index](#index-19)
+    - [Methods](#methods-7)
+  - [Class: Random](#class-random)
+    - [Hierarchy](#hierarchy-20)
+    - [Index](#index-20)
+    - [Methods](#methods-8)
+  - [Class: StringUtils](#class-stringutils)
+    - [Hierarchy](#hierarchy-21)
+    - [Index](#index-21)
+    - [Methods](#methods-9)
+  - [Class: subscription](#class-subscription)
+    - [Hierarchy](#hierarchy-22)
+    - [Index](#index-22)
+    - [Properties](#properties-14)
+  - [Class: subscription_clock](#class-subscription_clock)
+    - [Hierarchy](#hierarchy-23)
+    - [Index](#index-23)
+    - [Properties](#properties-15)
+  - [Class: subscription_fd_readwrite](#class-subscription_fd_readwrite)
+    - [Hierarchy](#hierarchy-24)
+    - [Index](#index-24)
+    - [Properties](#properties-16)
+  - [Class: Time](#class-time)
+    - [Hierarchy](#hierarchy-25)
+    - [Index](#index-25)
+    - [Properties](#properties-17)
+    - [Methods](#methods-10)
+  - [Class: WASIError](#class-wasierror)
+    - [Hierarchy](#hierarchy-26)
+    - [Index](#index-26)
+    - [Constructors](#constructors-4)
+    - [Properties](#properties-18)
+    - [Methods](#methods-11)
+- [assemblyscript](#assemblyscript-1)
+  - [Index](#index-27)
+    - [Namespaces](#namespaces)
+    - [Classes](#classes-1)
+    - [Type aliases](#type-aliases)
+    - [Functions](#functions)
+  - [Type aliases](#type-aliases-1)
+    - [aisize](#aisize)
+    - [char](#char)
+    - [device](#device)
+    - [dircookie](#dircookie)
+    - [exitcode](#exitcode)
+    - [fd](#fd)
+    - [filedelta](#filedelta)
+    - [filesize](#filesize)
+    - [inode](#inode)
+    - [linkcount](#linkcount)
+    - [ptr](#ptr)
+    - [struct](#struct)
+    - [timestamp](#timestamp)
+    - [userdata](#userdata)
+  - [Functions](#functions-1)
+    - [args_get](#args_get)
+    - [args_sizes_get](#args_sizes_get)
+    - [clock_res_get](#clock_res_get)
+    - [clock_time_get](#clock_time_get)
+    - [environ_get](#environ_get)
+    - [environ_sizes_get](#environ_sizes_get)
+    - [fd_advise](#fd_advise)
+    - [fd_allocate](#fd_allocate)
+    - [fd_close](#fd_close)
+    - [fd_datasync](#fd_datasync)
+    - [fd_fdstat_get](#fd_fdstat_get)
+    - [fd_fdstat_set_flags](#fd_fdstat_set_flags)
+    - [fd_fdstat_set_rights](#fd_fdstat_set_rights)
+    - [fd_filestat_get](#fd_filestat_get)
+    - [fd_filestat_set_size](#fd_filestat_set_size)
+    - [fd_filestat_set_times](#fd_filestat_set_times)
+    - [fd_pread](#fd_pread)
+    - [fd_prestat_dir_name](#fd_prestat_dir_name)
+    - [fd_prestat_get](#fd_prestat_get)
+    - [fd_pwrite](#fd_pwrite)
+    - [fd_read](#fd_read)
+    - [fd_readdir](#fd_readdir)
+    - [fd_renumber](#fd_renumber)
+    - [fd_seek](#fd_seek)
+    - [fd_sync](#fd_sync)
+    - [fd_tell](#fd_tell)
+    - [fd_write](#fd_write)
+    - [path_create_directory](#path_create_directory)
+    - [path_filestat_get](#path_filestat_get)
+    - [path_filestat_set_times](#path_filestat_set_times)
+    - [path_link](#path_link)
+    - [path_open](#path_open)
+    - [path_readlink](#path_readlink)
+    - [path_remove_directory](#path_remove_directory)
+    - [path_rename](#path_rename)
+    - [path_symlink](#path_symlink)
+    - [path_unlink_file](#path_unlink_file)
+    - [poll_oneoff](#poll_oneoff)
+    - [proc_exit](#proc_exit)
+    - [proc_raise](#proc_raise)
+    - [random_get](#random_get)
+    - [sched_yield](#sched_yield)
+    - [sock_recv](#sock_recv)
+    - [sock_send](#sock_send)
+    - [sock_shutdown](#sock_shutdown)
+    - [wasi_abort](#wasi_abort)
+- [Modules](#modules)
+  - [Namespace: advice](#namespace-advice)
+    - [Index](#index-28)
+    - [Variables](#variables)
+  - [Namespace: clockid](#namespace-clockid)
+    - [Index](#index-29)
+    - [Variables](#variables-1)
+  - [Namespace: errno](#namespace-errno)
+    - [Index](#index-30)
+    - [Variables](#variables-2)
+  - [Namespace: eventrwflags](#namespace-eventrwflags)
+    - [Index](#index-31)
+    - [Variables](#variables-3)
+  - [Namespace: eventtype](#namespace-eventtype)
+    - [Index](#index-32)
+    - [Variables](#variables-4)
+  - [Namespace: fdflags](#namespace-fdflags)
+    - [Index](#index-33)
+    - [Variables](#variables-5)
+  - [Namespace: filetype](#namespace-filetype)
+    - [Index](#index-34)
+    - [Variables](#variables-6)
+  - [Namespace: fstflags](#namespace-fstflags)
+    - [Index](#index-35)
+    - [Variables](#variables-7)
+  - [Namespace: lookupflags](#namespace-lookupflags)
+    - [Index](#index-36)
+    - [Variables](#variables-8)
+  - [Namespace: oflags](#namespace-oflags)
+    - [Index](#index-37)
+    - [Variables](#variables-9)
+  - [Namespace: preopentype](#namespace-preopentype)
+    - [Index](#index-38)
+    - [Variables](#variables-10)
+  - [Namespace: riflags](#namespace-riflags)
+    - [Index](#index-39)
+    - [Variables](#variables-11)
+  - [Namespace: rights](#namespace-rights)
+    - [Index](#index-40)
+    - [Variables](#variables-12)
+  - [Namespace: roflags](#namespace-roflags)
+    - [Index](#index-41)
+    - [Variables](#variables-13)
+  - [Namespace: sdflags](#namespace-sdflags)
+    - [Index](#index-42)
+    - [Variables](#variables-14)
+  - [Namespace: siflags](#namespace-siflags)
+  - [Namespace: signal](#namespace-signal)
+    - [Index](#index-43)
+    - [Variables](#variables-15)
+  - [Namespace: subclockflags](#namespace-subclockflags)
+    - [Index](#index-44)
+    - [Variables](#variables-16)
+  - [Namespace: whence](#namespace-whence)
+    - [Index](#index-45)
+    - [Variables](#variables-17)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+<a name="readmemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd)
+
+# assemblyscript
+
+Standard library
+================
+
+Standard library components for use with `tsc` (portable) and `asc` (assembly).
+
+Base configurations (.json) and definition files (.d.ts) are relevant to `tsc` only and not used by `asc`.
+
+# Classes
+
+
+<a name="classes_eventmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$event](#classes_eventmd)
+
+## Class: $event
+
+### Hierarchy
+
+* **$event**
+
+  ↳ [event](#classeseventmd)
+
+  ↳ [event_fd_readwrite](#classesevent_fd_readwritemd)
+
+### Index
+
+#### Properties
+
+* [__padding0](#private-__padding0)
+* [error](#error)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding0
+
+• **__padding0**: *u16*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:970
+
+___
+
+####  error
+
+• **error**: *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
+
+If non-zero, an error that occurred while processing the subscription request.
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
+
+The type of the event that occurred.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
+
+User-provided value that got attached to `subscription#userdata`.
+
+
+<a name="classes_prestatmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$prestat](#classes_prestatmd)
+
+## Class: $prestat
+
+### Hierarchy
+
+* **$prestat**
+
+  ↳ [prestat](#classesprestatmd)
+
+  ↳ [prestat_dir](#classesprestat_dirmd)
+
+### Index
+
+#### Properties
+
+* [type](#type)
+
+### Properties
+
+####  type
+
+• **type**: *[preopentype](#modulespreopentypemd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
+
+
+<a name="classes_subscriptionmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [$subscription](#classes_subscriptionmd)
+
+## Class: $subscription
+
+### Hierarchy
+
+* **$subscription**
+
+  ↳ [subscription](#classessubscriptionmd)
+
+  ↳ [subscription_clock](#classessubscription_clockmd)
+
+  ↳ [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
+
+### Index
+
+#### Properties
+
+* [__padding0](#private-__padding0)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding0
+
+• **__padding0**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1509
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
+
+The type of the event to which to subscribe.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
+
+User-provided value that is attached to the subscription.
+
+
+<a name="classescommandlinemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [CommandLine](#classescommandlinemd)
+
+## Class: CommandLine
+
+### Hierarchy
+
+* **CommandLine**
+
+### Index
+
+#### Constructors
+
+* [constructor](#constructor)
+
+#### Properties
+
+* [args](#args)
+
+#### Methods
+
+* [all](#all)
+* [get](#get)
+
+### Constructors
+
+####  constructor
+
+\+ **new CommandLine**(): *[CommandLine](#classescommandlinemd)*
+
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L929)*
+
+**Returns:** *[CommandLine](#classescommandlinemd)*
+
+### Properties
+
+####  args
+
+• **args**: *string[]*
+
+*Defined in [assembly/as-wasi.ts:929](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L929)*
+
+### Methods
+
+####  all
+
+▸ **all**(): *Array‹string›*
+
+*Defined in [assembly/as-wasi.ts:958](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L958)*
+
+Return all the command-line arguments
+
+**Returns:** *Array‹string›*
+
+___
+
+####  get
+
+▸ **get**(`i`: usize): *string | null*
+
+*Defined in [assembly/as-wasi.ts:966](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L966)*
+
+Return the i-th command-ine argument
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`i` | usize | index  |
+
+**Returns:** *string | null*
+
+
+<a name="classesconsolemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Console](#classesconsolemd)
+
+## Class: Console
+
+### Hierarchy
+
+* **Console**
+
+### Index
+
+#### Methods
+
+* [error](#static-error)
+* [log](#static-log)
+* [readAll](#static-readall)
+* [write](#static-write)
+
+### Methods
+
+#### `Static` error
+
+▸ **error**(`s`: string, `newline`: bool): *void*
+
+*Defined in [assembly/as-wasi.ts:804](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L804)*
+
+Write an error to the console
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`s` | string | - | string |
+`newline` | bool | true | `false` to avoid inserting a newline after the string  |
+
+**Returns:** *void*
+
+___
+
+#### `Static` log
+
+▸ **log**(`s`: string): *void*
+
+*Defined in [assembly/as-wasi.ts:795](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L795)*
+
+Alias for `Console.write()`
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`s` | string |
+
+**Returns:** *void*
+
+___
+
+#### `Static` readAll
+
+▸ **readAll**(): *string | null*
+
+*Defined in [assembly/as-wasi.ts:788](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L788)*
+
+Read an UTF8 string from the console, convert it to a native string
+
+**Returns:** *string | null*
+
+___
+
+#### `Static` write
+
+▸ **write**(`s`: string, `newline`: bool): *void*
+
+*Defined in [assembly/as-wasi.ts:781](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L781)*
+
+Write a string to the console
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`s` | string | - | string |
+`newline` | bool | true | `false` to avoid inserting a newline after the string  |
+
+**Returns:** *void*
+
+
+<a name="classesdatemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Date](#classesdatemd)
+
+## Class: Date
+
+### Hierarchy
+
+* **Date**
+
+### Index
+
+#### Methods
+
+* [now](#static-now)
+
+### Methods
+
+#### `Static` now
+
+▸ **now**(): *f64*
+
+*Defined in [assembly/as-wasi.ts:842](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L842)*
+
+Return the current timestamp, as a number of milliseconds since the epoch
+
+**Returns:** *f64*
+
+
+<a name="classesdescriptormd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Descriptor](#classesdescriptormd)
+
+## Class: Descriptor
+
+A descriptor, that doesn't necessarily have to represent a file
+
+### Hierarchy
+
+* **Descriptor**
+
+### Index
+
+#### Constructors
+
+* [constructor](#constructor)
+
+#### Accessors
+
+* [rawfd](#rawfd)
+* [Invalid](#static-invalid)
+* [Stderr](#static-stderr)
+* [Stdin](#static-stdin)
+* [Stdout](#static-stdout)
+
+#### Methods
+
+* [advise](#advise)
+* [allocate](#allocate)
+* [close](#close)
+* [dirName](#dirname)
+* [fatime](#fatime)
+* [fdatasync](#fdatasync)
+* [fileType](#filetype)
+* [fmtime](#fmtime)
+* [fsync](#fsync)
+* [ftruncate](#ftruncate)
+* [futimes](#futimes)
+* [read](#read)
+* [readAll](#readall)
+* [readString](#readstring)
+* [seek](#seek)
+* [setFlags](#setflags)
+* [stat](#stat)
+* [tell](#tell)
+* [touch](#touch)
+* [write](#write)
+* [writeString](#writestring)
+* [writeStringLn](#writestringln)
+
+### Constructors
+
+####  constructor
+
+\+ **new Descriptor**(`rawfd`: fd): *[Descriptor](#classesdescriptormd)*
+
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L109)*
+
+Build a new descriptor from a raw WASI file descriptor
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`rawfd` | fd | a raw file descriptor  |
+
+**Returns:** *[Descriptor](#classesdescriptormd)*
+
+### Accessors
+
+####  rawfd
+
+• **get rawfd**(): *fd*
+
+*Defined in [assembly/as-wasi.ts:119](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L119)*
+
+**Returns:** *fd*
+
+___
+
+#### `Static` Invalid
+
+• **get Invalid**(): *[Descriptor](#classesdescriptormd)*
+
+*Defined in [assembly/as-wasi.ts:94](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L94)*
+
+An invalid file descriptor, that can represent an error
+
+**Returns:** *[Descriptor](#classesdescriptormd)*
+
+___
+
+#### `Static` Stderr
+
+• **get Stderr**(): *[Descriptor](#classesdescriptormd)*
+
+*Defined in [assembly/as-wasi.ts:109](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L109)*
+
+The standard error
+
+**Returns:** *[Descriptor](#classesdescriptormd)*
+
+___
+
+#### `Static` Stdin
+
+• **get Stdin**(): *[Descriptor](#classesdescriptormd)*
+
+*Defined in [assembly/as-wasi.ts:99](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L99)*
+
+The standard input
+
+**Returns:** *[Descriptor](#classesdescriptormd)*
+
+___
+
+#### `Static` Stdout
+
+• **get Stdout**(): *[Descriptor](#classesdescriptormd)*
+
+*Defined in [assembly/as-wasi.ts:104](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L104)*
+
+The standard output
+
+**Returns:** *[Descriptor](#classesdescriptormd)*
+
+### Methods
+
+####  advise
+
+▸ **advise**(`offset`: u64, `len`: u64, `advice`: advice): *bool*
+
+*Defined in [assembly/as-wasi.ts:130](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L130)*
+
+Hint at how the data accessible via the descriptor will be used
+
+**`offset`** offset
+
+**`len`** length
+
+**`advice`** `advice.{NORMAL, SEQUENTIAL, RANDOM, WILLNEED, DONTNEED, NOREUSE}`
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`offset` | u64 |
+`len` | u64 |
+`advice` | advice |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  allocate
+
+▸ **allocate**(`offset`: u64, `len`: u64): *bool*
+
+*Defined in [assembly/as-wasi.ts:140](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L140)*
+
+Preallocate data
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`offset` | u64 | where to start preallocating data in the file |
+`len` | u64 | bytes to preallocate |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  close
+
+▸ **close**(): *void*
+
+*Defined in [assembly/as-wasi.ts:283](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L283)*
+
+Close a file descriptor
+
+**Returns:** *void*
+
+___
+
+####  dirName
+
+▸ **dirName**(): *string*
+
+*Defined in [assembly/as-wasi.ts:261](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L261)*
+
+Return the directory associated to that descriptor
+
+**Returns:** *string*
+
+___
+
+####  fatime
+
+▸ **fatime**(`ts`: f64): *bool*
+
+*Defined in [assembly/as-wasi.ts:207](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L207)*
+
+Update the access time
+
+**`ts`** timestamp in seconds
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`ts` | f64 |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  fdatasync
+
+▸ **fdatasync**(): *bool*
+
+*Defined in [assembly/as-wasi.ts:148](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L148)*
+
+Wait for the data to be written
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  fileType
+
+▸ **fileType**(): *[filetype](#filetype)*
+
+*Defined in [assembly/as-wasi.ts:163](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L163)*
+
+Return the file type
+
+**Returns:** *[filetype](#filetype)*
+
+___
+
+####  fmtime
+
+▸ **fmtime**(`ts`: f64): *bool*
+
+*Defined in [assembly/as-wasi.ts:219](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L219)*
+
+Update the modification time
+
+**`ts`** timestamp in seconds
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`ts` | f64 |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  fsync
+
+▸ **fsync**(): *bool*
+
+*Defined in [assembly/as-wasi.ts:156](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L156)*
+
+Wait for the data and metadata to be written
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  ftruncate
+
+▸ **ftruncate**(`size`: u64): *bool*
+
+*Defined in [assembly/as-wasi.ts:198](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L198)*
+
+Change the size of a file
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`size` | u64 | 0 | new size |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  futimes
+
+▸ **futimes**(`atime`: f64, `mtime`: f64): *bool*
+
+*Defined in [assembly/as-wasi.ts:232](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L232)*
+
+Update both the access and the modification times
+
+**`atime`** timestamp in seconds
+
+**`mtime`** timestamp in seconds
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`atime` | f64 |
+`mtime` | f64 |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  read
+
+▸ **read**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
+
+*Defined in [assembly/as-wasi.ts:348](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L348)*
+
+Read data from a file descriptor
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`data` | u8[] | [] | existing array to push data to |
+`chunk_size` | usize | 4096 | chunk size (default: 4096)  |
+
+**Returns:** *u8[] | null*
+
+___
+
+####  readAll
+
+▸ **readAll**(`data`: u8[], `chunk_size`: usize): *u8[] | null*
+
+*Defined in [assembly/as-wasi.ts:373](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L373)*
+
+Read from a file descriptor until the end of the stream
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`data` | u8[] | [] | existing array to push data to |
+`chunk_size` | usize | 4096 | chunk size (default: 4096)  |
+
+**Returns:** *u8[] | null*
+
+___
+
+####  readString
+
+▸ **readString**(`chunk_size`: usize): *string | null*
+
+*Defined in [assembly/as-wasi.ts:404](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L404)*
+
+Read an UTF8 string from a file descriptor, convert it to a native string
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`chunk_size` | usize | 4096 | chunk size (default: 4096)  |
+
+**Returns:** *string | null*
+
+___
+
+####  seek
+
+▸ **seek**(`off`: u64, `w`: whence): *bool*
+
+*Defined in [assembly/as-wasi.ts:418](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L418)*
+
+Seek into a stream
+
+**`off`** offset
+
+**`w`** the position relative to which to set the offset of the file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`off` | u64 |
+`w` | whence |
+
+**Returns:** *bool*
+
+___
+
+####  setFlags
+
+▸ **setFlags**(`flags`: [fdflags](#modulesfdflagsmd)): *bool*
+
+*Defined in [assembly/as-wasi.ts:177](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L177)*
+
+Set WASI flags for that descriptor
+
+**`params`** flags: one or more of `fdflags.{APPEND, DSYNC, NONBLOCK, RSYNC, SYNC}`
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`flags` | [fdflags](#modulesfdflagsmd) |
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  stat
+
+▸ **stat**(): *[FileStat](#classesfilestatmd)*
+
+*Defined in [assembly/as-wasi.ts:185](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L185)*
+
+Retrieve information about a descriptor
+
+**Returns:** *[FileStat](#classesfilestatmd)*
+
+a `FileStat` object`
+
+___
+
+####  tell
+
+▸ **tell**(): *u64*
+
+*Defined in [assembly/as-wasi.ts:429](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L429)*
+
+Return the current offset in the stream
+
+**Returns:** *u64*
+
+offset
+
+___
+
+####  touch
+
+▸ **touch**(): *bool*
+
+*Defined in [assembly/as-wasi.ts:247](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L247)*
+
+Update the timestamp of the object represented by the descriptor
+
+**Returns:** *bool*
+
+`true` on success, `false` on error
+
+___
+
+####  write
+
+▸ **write**(`data`: u8[]): *void*
+
+*Defined in [assembly/as-wasi.ts:291](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L291)*
+
+Write data to a file descriptor
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`data` | u8[] | data  |
+
+**Returns:** *void*
+
+___
+
+####  writeString
+
+▸ **writeString**(`s`: string, `newline`: bool): *void*
+
+*Defined in [assembly/as-wasi.ts:309](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L309)*
+
+Write a string to a file descriptor, after encoding it to UTF8
+
+**Parameters:**
+
+Name | Type | Default | Description |
+------ | ------ | ------ | ------ |
+`s` | string | - | string |
+`newline` | bool | false | `true` to add a newline after the string  |
+
+**Returns:** *void*
+
+___
+
+####  writeStringLn
+
+▸ **writeStringLn**(`s`: string): *void*
+
+*Defined in [assembly/as-wasi.ts:328](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L328)*
+
+Write a string to a file descriptor, after encoding it to UTF8, with a newline
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`s` | string | string  |
+
+**Returns:** *void*
+
+
+<a name="classesdirentmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [dirent](#classesdirentmd)
+
+## Class: dirent
+
+A directory entry.
+
+### Hierarchy
+
+* **dirent**
+
+### Index
+
+#### Properties
+
+* [__padding0](#private-__padding0)
+* [ino](#ino)
+* [namlen](#namlen)
+* [next](#next)
+* [type](#type)
+
+### Properties
+
+#### `Private` __padding0
+
+• **__padding0**: *u16*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:646
+
+___
+
+####  ino
+
+• **ino**: *[inode](#inode)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:641
+
+The serial number of the file referred to by this directory entry.
+
+___
+
+####  namlen
+
+• **namlen**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:643
+
+The length of the name of the directory entry.
+
+___
+
+####  next
+
+• **next**: *[dircookie](#dircookie)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:639
+
+The offset of the next directory entry stored in this directory.
+
+___
+
+####  type
+
+• **type**: *[filetype](#filetype)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:645
+
+The type of the file referred to by this directory entry.
+
+
+<a name="classesenvironmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Environ](#classesenvironmd)
+
+## Class: Environ
+
+### Hierarchy
+
+* **Environ**
+
+### Index
+
+#### Constructors
+
+* [constructor](#constructor)
+
+#### Properties
+
+* [env](#env)
+
+#### Methods
+
+* [all](#all)
+* [get](#get)
+
+### Constructors
+
+####  constructor
+
+\+ **new Environ**(): *[Environ](#classesenvironmd)*
+
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L877)*
+
+**Returns:** *[Environ](#classesenvironmd)*
+
+### Properties
+
+####  env
+
+• **env**: *Array‹[EnvironEntry](#classesenvironentrymd)›*
+
+*Defined in [assembly/as-wasi.ts:877](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L877)*
+
+### Methods
+
+####  all
+
+▸ **all**(): *Array‹[EnvironEntry](#classesenvironentrymd)›*
+
+*Defined in [assembly/as-wasi.ts:908](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L908)*
+
+ Return all environment variables
+
+**Returns:** *Array‹[EnvironEntry](#classesenvironentrymd)›*
+
+___
+
+####  get
+
+▸ **get**(`key`: string): *string | null*
+
+*Defined in [assembly/as-wasi.ts:916](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L916)*
+
+Return the value for an environment variable
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`key` | string | environment variable name  |
+
+**Returns:** *string | null*
+
+
+<a name="classesenvironentrymd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [EnvironEntry](#classesenvironentrymd)
+
+## Class: EnvironEntry
+
+### Hierarchy
+
+* **EnvironEntry**
+
+### Index
+
+#### Constructors
+
+* [constructor](#constructor)
+
+#### Properties
+
+* [key](#readonly-key)
+* [value](#readonly-value)
+
+### Constructors
+
+####  constructor
+
+\+ **new EnvironEntry**(`key`: string, `value`: string): *[EnvironEntry](#classesenvironentrymd)*
+
+*Defined in [assembly/as-wasi.ts:872](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L872)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`key` | string |
+`value` | string |
+
+**Returns:** *[EnvironEntry](#classesenvironentrymd)*
+
+### Properties
+
+#### `Readonly` key
+
+• **key**: *string*
+
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L873)*
+
+___
+
+#### `Readonly` value
+
+• **value**: *string*
+
+*Defined in [assembly/as-wasi.ts:873](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L873)*
+
+
+<a name="classeseventmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [event](#classeseventmd)
+
+## Class: event
+
+An event that occurred.
+
+### Hierarchy
+
+* [$event](#classes_eventmd)
+
+  ↳ **event**
+
+### Index
+
+#### Properties
+
+* [__padding1](#private-__padding1)
+* [__padding2](#private-__padding2)
+* [error](#error)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding1
+
+• **__padding1**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:975
+
+___
+
+#### `Private` __padding2
+
+• **__padding2**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:976
+
+___
+
+####  error
+
+• **error**: *[errno](#moduleserrnomd)*
+
+*Inherited from [$event](#classes_eventmd).[error](#error)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
+
+If non-zero, an error that occurred while processing the subscription request.
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+*Inherited from [$event](#classes_eventmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
+
+The type of the event that occurred.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+*Inherited from [$event](#classes_eventmd).[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
+
+User-provided value that got attached to `subscription#userdata`.
+
+
+<a name="classesevent_fd_readwritemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [event_fd_readwrite](#classesevent_fd_readwritemd)
+
+## Class: event_fd_readwrite
+
+An event that occurred when type is `eventtype.FD_READ` or `eventtype.FD_WRITE`.
+
+### Hierarchy
+
+* [$event](#classes_eventmd)
+
+  ↳ **event_fd_readwrite**
+
+### Index
+
+#### Properties
+
+* [__padding1](#private-__padding1)
+* [error](#error)
+* [flags](#flags)
+* [nbytes](#nbytes)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding1
+
+• **__padding1**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:986
+
+___
+
+####  error
+
+• **error**: *[errno](#moduleserrnomd)*
+
+*Inherited from [$event](#classes_eventmd).[error](#error)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:966
+
+If non-zero, an error that occurred while processing the subscription request.
+
+___
+
+####  flags
+
+• **flags**: *[eventrwflags](#moduleseventrwflagsmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:984
+
+___
+
+####  nbytes
+
+• **nbytes**: *[filesize](#filesize)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:982
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+*Inherited from [$event](#classes_eventmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:968
+
+The type of the event that occurred.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+*Inherited from [$event](#classes_eventmd).[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:964
+
+User-provided value that got attached to `subscription#userdata`.
+
+
+<a name="classesfdstatmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fdstat](#classesfdstatmd)
+
+## Class: fdstat
+
+File descriptor attributes.
+
+### Hierarchy
+
+* **fdstat**
+
+### Index
+
+#### Properties
+
+* [filetype](#filetype)
+* [flags](#flags)
+* [rights_base](#rights_base)
+* [rights_inheriting](#rights_inheriting)
+
+### Properties
+
+####  filetype
+
+• **filetype**: *[filetype](#filetype)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1049
+
+File type.
+
+___
+
+####  flags
+
+• **flags**: *[fdflags](#modulesfdflagsmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1051
+
+File descriptor flags.
+
+___
+
+####  rights_base
+
+• **rights_base**: *[rights](#modulesrightsmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1053
+
+Rights that apply to this file descriptor.
+
+___
+
+####  rights_inheriting
+
+• **rights_inheriting**: *[rights](#modulesrightsmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1055
+
+Maximum set of rights that may be installed on new file descriptors that are created through this file descriptor, e.g., through `path_open`.
+
+
+<a name="classesfilestatmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [filestat](#classesfilestatmd)
+
+## Class: filestat
+
+File attributes.
+
+### Hierarchy
+
+* **filestat**
+
+### Index
+
+#### Properties
+
+* [atim](#atim)
+* [ctim](#ctim)
+* [dev](#dev)
+* [filetype](#filetype)
+* [ino](#ino)
+* [mtim](#mtim)
+* [nlink](#nlink)
+* [size](#size)
+
+### Properties
+
+####  atim
+
+• **atim**: *[timestamp](#timestamp)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1077
+
+Last data access timestamp.
+
+___
+
+####  ctim
+
+• **ctim**: *[timestamp](#timestamp)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1081
+
+Last file status change timestamp.
+
+___
+
+####  dev
+
+• **dev**: *[device](#device)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1067
+
+Device ID of device containing the file.
+
+___
+
+####  filetype
+
+• **filetype**: *[filetype](#filetype)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1071
+
+File type.
+
+___
+
+####  ino
+
+• **ino**: *[inode](#inode)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1069
+
+File serial number.
+
+___
+
+####  mtim
+
+• **mtim**: *[timestamp](#timestamp)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1079
+
+Last data modification timestamp.
+
+___
+
+####  nlink
+
+• **nlink**: *[linkcount](#linkcount)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1073
+
+Number of hard links to the file.
+
+___
+
+####  size
+
+• **size**: *[filesize](#filesize)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1075
+
+For regular files, the file size in bytes. For symbolic links, the length in bytes of the pathname contained in the symbolic link.
+
+
+<a name="classesfilesystemmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [FileSystem](#classesfilesystemmd)
+
+## Class: FileSystem
+
+A class to access a filesystem
+
+### Hierarchy
+
+* **FileSystem**
+
+### Index
+
+#### Methods
+
+* [dirfdForPath](#static-protected-dirfdforpath)
+* [exists](#static-exists)
+* [link](#static-link)
+* [lstat](#static-lstat)
+* [mkdir](#static-mkdir)
+* [open](#static-open)
+* [readdir](#static-readdir)
+* [rename](#static-rename)
+* [rmdir](#static-rmdir)
+* [stat](#static-stat)
+* [symlink](#static-symlink)
+* [unlink](#static-unlink)
+
+### Methods
+
+#### `Static` `Protected` dirfdForPath
+
+▸ **dirfdForPath**(`path`: string): *fd*
+
+*Defined in [assembly/as-wasi.ts:769](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L769)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *fd*
+
+___
+
+#### `Static` exists
+
+▸ **exists**(`path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:533](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L533)*
+
+Check if a file exists at a given path
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` link
+
+▸ **link**(`old_path`: string, `new_path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:556](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L556)*
+
+Create a hard link
+
+**`old_path`** old path
+
+**`new_path`** new path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_path` | string |
+`new_path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` lstat
+
+▸ **lstat**(`path`: string): *[FileStat](#classesfilestatmd)*
+
+*Defined in [assembly/as-wasi.ts:672](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L672)*
+
+Retrieve information about a file or a symbolic link
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *[FileStat](#classesfilestatmd)*
+
+a `FileStat` object
+
+___
+
+#### `Static` mkdir
+
+▸ **mkdir**(`path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:516](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L516)*
+
+Create a new directory
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` open
+
+▸ **open**(`path`: string, `flags`: string): *[Descriptor](#classesdescriptormd) | null*
+
+*Defined in [assembly/as-wasi.ts:449](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L449)*
+
+Open a path
+
+**`path`** path
+
+**`flags`** r, r+, w, wx, w+ or xw+
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`path` | string | - |
+`flags` | string | "r" |
+
+**Returns:** *[Descriptor](#classesdescriptormd) | null*
+
+a descriptor
+
+___
+
+#### `Static` readdir
+
+▸ **readdir**(`path`: string): *Array‹string› | null*
+
+*Defined in [assembly/as-wasi.ts:726](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L726)*
+
+Get the content of a directory
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`path` | string | the directory path |
+
+**Returns:** *Array‹string› | null*
+
+An array of file names
+
+___
+
+#### `Static` rename
+
+▸ **rename**(`old_path`: string, `new_path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:698](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L698)*
+
+Rename a file
+
+**`old_path`** old path
+
+**`new_path`** new path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_path` | string |
+`new_path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` rmdir
+
+▸ **rmdir**(`path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:630](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L630)*
+
+Remove a directory
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` stat
+
+▸ **stat**(`path`: string): *[FileStat](#classesfilestatmd)*
+
+*Defined in [assembly/as-wasi.ts:647](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L647)*
+
+Retrieve information about a file
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *[FileStat](#classesfilestatmd)*
+
+a `FileStat` object
+
+___
+
+#### `Static` symlink
+
+▸ **symlink**(`old_path`: string, `new_path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:587](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L587)*
+
+Create a symbolic link
+
+**`old_path`** old path
+
+**`new_path`** new path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_path` | string |
+`new_path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+___
+
+#### `Static` unlink
+
+▸ **unlink**(`path`: string): *bool*
+
+*Defined in [assembly/as-wasi.ts:613](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L613)*
+
+Unlink a file
+
+**`path`** path
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`path` | string |
+
+**Returns:** *bool*
+
+`true` on success, `false` on failure
+
+
+<a name="classesiovecmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [iovec](#classesiovecmd)
+
+## Class: iovec
+
+A region of memory for scatter/gather reads.
+
+### Hierarchy
+
+* **iovec**
+
+### Index
+
+#### Properties
+
+* [buf](#buf)
+* [buf_len](#buf_len)
+
+### Properties
+
+####  buf
+
+• **buf**: *usize*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1148
+
+The address of the buffer to be filled.
+
+___
+
+####  buf_len
+
+• **buf_len**: *usize*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1150
+
+The length of the buffer to be filled.
+
+
+<a name="classesperformancemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Performance](#classesperformancemd)
+
+## Class: Performance
+
+### Hierarchy
+
+* **Performance**
+
+### Index
+
+#### Methods
+
+* [now](#static-now)
+
+### Methods
+
+#### `Static` now
+
+▸ **now**(): *f64*
+
+*Defined in [assembly/as-wasi.ts:852](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L852)*
+
+**Returns:** *f64*
+
+
+<a name="classesprestatmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [prestat](#classesprestatmd)
+
+## Class: prestat
+
+### Hierarchy
+
+* [$prestat](#classes_prestatmd)
+
+  ↳ **prestat**
+
+### Index
+
+#### Properties
+
+* [__padding0](#private-__padding0)
+* [type](#type)
+
+### Properties
+
+#### `Private` __padding0
+
+• **__padding0**: *usize*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1202
+
+___
+
+####  type
+
+• **type**: *[preopentype](#modulespreopentypemd)*
+
+*Inherited from [$prestat](#classes_prestatmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
+
+
+<a name="classesprestat_dirmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [prestat_dir](#classesprestat_dirmd)
+
+## Class: prestat_dir
+
+The contents of a $prestat when type is `preopentype.DIR`.
+
+### Hierarchy
+
+* [$prestat](#classes_prestatmd)
+
+  ↳ **prestat_dir**
+
+### Index
+
+#### Properties
+
+* [name_len](#name_len)
+* [type](#type)
+
+### Properties
+
+####  name_len
+
+• **name_len**: *usize*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1208
+
+The length of the directory name for use with `fd_prestat_dir_name`.
+
+___
+
+####  type
+
+• **type**: *[preopentype](#modulespreopentypemd)*
+
+*Inherited from [$prestat](#classes_prestatmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1197
+
+
+<a name="classesprocessmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Process](#classesprocessmd)
+
+## Class: Process
+
+### Hierarchy
+
+* **Process**
+
+### Index
+
+#### Methods
+
+* [exit](#static-exit)
+
+### Methods
+
+#### `Static` exit
+
+▸ **exit**(`status`: u32): *void*
+
+*Defined in [assembly/as-wasi.ts:867](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L867)*
+
+Cleanly terminate the current process
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`status` | u32 | exit code  |
+
+**Returns:** *void*
+
+
+<a name="classesrandommd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Random](#classesrandommd)
+
+## Class: Random
+
+### Hierarchy
+
+* **Random**
+
+### Index
+
+#### Methods
+
+* [randomBytes](#static-randombytes)
+* [randomFill](#static-randomfill)
+
+### Methods
+
+#### `Static` randomBytes
+
+▸ **randomBytes**(`len`: usize): *Uint8Array*
+
+*Defined in [assembly/as-wasi.ts:831](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L831)*
+
+Return an array of random bytes
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`len` | usize | length  |
+
+**Returns:** *Uint8Array*
+
+___
+
+#### `Static` randomFill
+
+▸ **randomFill**(`buffer`: ArrayBuffer): *void*
+
+*Defined in [assembly/as-wasi.ts:814](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L814)*
+
+Fill a buffer with random data
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`buffer` | ArrayBuffer | An array buffer  |
+
+**Returns:** *void*
+
+
+<a name="classesstringutilsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [StringUtils](#classesstringutilsmd)
+
+## Class: StringUtils
+
+### Hierarchy
+
+* **StringUtils**
+
+### Index
+
+#### Methods
+
+* [fromCString](#static-fromcstring)
+
+### Methods
+
+#### `Static` fromCString
+
+▸ **fromCString**(`cstring`: usize): *string*
+
+*Defined in [assembly/as-wasi.ts:1023](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L1023)*
+
+Returns a native string from a zero-terminated C string
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`cstring` | usize |
+
+**Returns:** *string*
+
+native string
+
+
+<a name="classessubscriptionmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription](#classessubscriptionmd)
+
+## Class: subscription
+
+Subscription to an event.
+
+### Hierarchy
+
+* [$subscription](#classes_subscriptionmd)
+
+  ↳ **subscription**
+
+### Index
+
+#### Properties
+
+* [__padding1](#private-__padding1)
+* [__padding2](#private-__padding2)
+* [__padding3](#private-__padding3)
+* [__padding4](#private-__padding4)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding1
+
+• **__padding1**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1514
+
+___
+
+#### `Private` __padding2
+
+• **__padding2**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1515
+
+___
+
+#### `Private` __padding3
+
+• **__padding3**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1516
+
+___
+
+#### `Private` __padding4
+
+• **__padding4**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1517
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
+
+The type of the event to which to subscribe.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
+
+User-provided value that is attached to the subscription.
+
+
+<a name="classessubscription_clockmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription_clock](#classessubscription_clockmd)
+
+## Class: subscription_clock
+
+### Hierarchy
+
+* [$subscription](#classes_subscriptionmd)
+
+  ↳ **subscription_clock**
+
+### Index
+
+#### Properties
+
+* [__padding1](#private-__padding1)
+* [clock_id](#clock_id)
+* [flags](#flags)
+* [precision](#precision)
+* [timeout](#timeout)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding1
+
+• **__padding1**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1531
+
+___
+
+####  clock_id
+
+• **clock_id**: *[clockid](#modulesclockidmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1523
+
+The clock against which to compare the timestamp.
+
+___
+
+####  flags
+
+• **flags**: *[subclockflags](#modulessubclockflagsmd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1529
+
+Flags specifying whether the timeout is absolute or relative.
+
+___
+
+####  precision
+
+• **precision**: *[timestamp](#timestamp)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1527
+
+The amount of time that the implementation may wait additionally to coalesce with other events.
+
+___
+
+####  timeout
+
+• **timeout**: *[timestamp](#timestamp)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1525
+
+The absolute or relative timestamp.
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
+
+The type of the event to which to subscribe.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
+
+User-provided value that is attached to the subscription.
+
+
+<a name="classessubscription_fd_readwritemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
+
+## Class: subscription_fd_readwrite
+
+### Hierarchy
+
+* [$subscription](#classes_subscriptionmd)
+
+  ↳ **subscription_fd_readwrite**
+
+### Index
+
+#### Properties
+
+* [__padding1](#private-__padding1)
+* [__padding2](#private-__padding2)
+* [__padding3](#private-__padding3)
+* [file_descriptor](#file_descriptor)
+* [type](#type)
+* [userdata](#userdata)
+
+### Properties
+
+#### `Private` __padding1
+
+• **__padding1**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1539
+
+___
+
+#### `Private` __padding2
+
+• **__padding2**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1540
+
+___
+
+#### `Private` __padding3
+
+• **__padding3**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1541
+
+___
+
+####  file_descriptor
+
+• **file_descriptor**: *fd*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1537
+
+The file descriptor on which to wait for it to become ready for reading or writing.
+
+___
+
+####  type
+
+• **type**: *[eventtype](#moduleseventtypemd)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[type](#type)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1507
+
+The type of the event to which to subscribe.
+
+___
+
+####  userdata
+
+• **userdata**: *[userdata](#userdata)*
+
+*Inherited from [$subscription](#classes_subscriptionmd).[userdata](#userdata)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1505
+
+User-provided value that is attached to the subscription.
+
+
+<a name="classestimemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [Time](#classestimemd)
+
+## Class: Time
+
+### Hierarchy
+
+* **Time**
+
+### Index
+
+#### Properties
+
+* [MILLISECOND](#static-millisecond)
+* [NANOSECOND](#static-nanosecond)
+* [SECOND](#static-second)
+
+#### Methods
+
+* [sleep](#static-sleep)
+
+### Properties
+
+#### `Static` MILLISECOND
+
+▪ **MILLISECOND**: *i32* = Time.NANOSECOND * 1000000
+
+*Defined in [assembly/as-wasi.ts:978](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L978)*
+
+___
+
+#### `Static` NANOSECOND
+
+▪ **NANOSECOND**: *i32* = 1
+
+*Defined in [assembly/as-wasi.ts:977](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L977)*
+
+___
+
+#### `Static` SECOND
+
+▪ **SECOND**: *i32* = Time.MILLISECOND * 1000
+
+*Defined in [assembly/as-wasi.ts:979](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L979)*
+
+### Methods
+
+#### `Static` sleep
+
+▸ **sleep**(`nanoseconds`: i32): *void*
+
+*Defined in [assembly/as-wasi.ts:983](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L983)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`nanoseconds` | i32 |
+
+**Returns:** *void*
+
+
+<a name="classeswasierrormd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [WASIError](#classeswasierrormd)
+
+## Class: WASIError
+
+A WASI error
+
+### Hierarchy
+
+* Error
+
+  ↳ **WASIError**
+
+### Index
+
+#### Constructors
+
+* [constructor](#constructor)
+
+#### Properties
+
+* [message](#message)
+* [name](#name)
+* [stack](#optional-stack)
+
+#### Methods
+
+* [toString](#tostring)
+
+### Constructors
+
+####  constructor
+
+\+ **new WASIError**(`message`: string): *[WASIError](#classeswasierrormd)*
+
+*Overrides void*
+
+*Defined in [assembly/as-wasi.ts:60](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L60)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`message` | string | "" |
+
+**Returns:** *[WASIError](#classeswasierrormd)*
+
+### Properties
+
+####  message
+
+• **message**: *string*
+
+*Inherited from [WASIError](#classeswasierrormd).[message](#message)*
+
+Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1578
+
+Message provided on construction.
+
+___
+
+####  name
+
+• **name**: *string*
+
+*Inherited from [WASIError](#classeswasierrormd).[name](#name)*
+
+Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1575
+
+Error name.
+
+___
+
+#### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [WASIError](#classeswasierrormd).[stack](#optional-stack)*
+
+Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1581
+
+Stack trace.
+
+### Methods
+
+####  toString
+
+▸ **toString**(): *string*
+
+*Inherited from [WASIError](#classeswasierrormd).[toString](#tostring)*
+
+Defined in node_modules/assemblyscript/std/assembly/index.d.ts:1587
+
+Method returns a string representing the specified Error class.
+
+**Returns:** *string*
+
+
+<a name="globalsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd)
+
+# assemblyscript
+
+## Index
+
+### Namespaces
+
+* [advice](#modulesadvicemd)
+* [clockid](#modulesclockidmd)
+* [errno](#moduleserrnomd)
+* [eventrwflags](#moduleseventrwflagsmd)
+* [eventtype](#moduleseventtypemd)
+* [fdflags](#modulesfdflagsmd)
+* [filetype](#modulesfiletypemd)
+* [fstflags](#modulesfstflagsmd)
+* [lookupflags](#moduleslookupflagsmd)
+* [oflags](#modulesoflagsmd)
+* [preopentype](#modulespreopentypemd)
+* [riflags](#modulesriflagsmd)
+* [rights](#modulesrightsmd)
+* [roflags](#modulesroflagsmd)
+* [sdflags](#modulessdflagsmd)
+* [siflags](#modulessiflagsmd)
+* [signal](#modulessignalmd)
+* [subclockflags](#modulessubclockflagsmd)
+* [whence](#moduleswhencemd)
+
+### Classes
+
+* [$event](#classes_eventmd)
+* [$prestat](#classes_prestatmd)
+* [$subscription](#classes_subscriptionmd)
+* [CommandLine](#classescommandlinemd)
+* [Console](#classesconsolemd)
+* [Date](#classesdatemd)
+* [Descriptor](#classesdescriptormd)
+* [Environ](#classesenvironmd)
+* [EnvironEntry](#classesenvironentrymd)
+* [FileStat](#classesfilestatmd)
+* [FileSystem](#classesfilesystemmd)
+* [Performance](#classesperformancemd)
+* [Process](#classesprocessmd)
+* [Random](#classesrandommd)
+* [StringUtils](#classesstringutilsmd)
+* [Time](#classestimemd)
+* [WASIError](#classeswasierrormd)
+* [dirent](#classesdirentmd)
+* [event](#classeseventmd)
+* [event_fd_readwrite](#classesevent_fd_readwritemd)
+* [fdstat](#classesfdstatmd)
+* [filestat](#classesfilestatmd)
+* [iovec](#classesiovecmd)
+* [prestat](#classesprestatmd)
+* [prestat_dir](#classesprestat_dirmd)
+* [subscription](#classessubscriptionmd)
+* [subscription_clock](#classessubscription_clockmd)
+* [subscription_fd_readwrite](#classessubscription_fd_readwritemd)
+
+### Type aliases
+
+* [aisize](#aisize)
+* [char](#char)
+* [device](#device)
+* [dircookie](#dircookie)
+* [exitcode](#exitcode)
+* [fd](#fd)
+* [filedelta](#filedelta)
+* [filesize](#filesize)
+* [inode](#inode)
+* [linkcount](#linkcount)
+* [ptr](#ptr)
+* [struct](#struct)
+* [timestamp](#timestamp)
+* [userdata](#userdata)
+
+### Functions
+
+* [args_get](#args_get)
+* [args_sizes_get](#args_sizes_get)
+* [clock_res_get](#clock_res_get)
+* [clock_time_get](#clock_time_get)
+* [environ_get](#environ_get)
+* [environ_sizes_get](#environ_sizes_get)
+* [fd_advise](#fd_advise)
+* [fd_allocate](#fd_allocate)
+* [fd_close](#fd_close)
+* [fd_datasync](#fd_datasync)
+* [fd_fdstat_get](#fd_fdstat_get)
+* [fd_fdstat_set_flags](#fd_fdstat_set_flags)
+* [fd_fdstat_set_rights](#fd_fdstat_set_rights)
+* [fd_filestat_get](#fd_filestat_get)
+* [fd_filestat_set_size](#fd_filestat_set_size)
+* [fd_filestat_set_times](#fd_filestat_set_times)
+* [fd_pread](#fd_pread)
+* [fd_prestat_dir_name](#fd_prestat_dir_name)
+* [fd_prestat_get](#fd_prestat_get)
+* [fd_pwrite](#fd_pwrite)
+* [fd_read](#fd_read)
+* [fd_readdir](#fd_readdir)
+* [fd_renumber](#fd_renumber)
+* [fd_seek](#fd_seek)
+* [fd_sync](#fd_sync)
+* [fd_tell](#fd_tell)
+* [fd_write](#fd_write)
+* [path_create_directory](#path_create_directory)
+* [path_filestat_get](#path_filestat_get)
+* [path_filestat_set_times](#path_filestat_set_times)
+* [path_link](#path_link)
+* [path_open](#path_open)
+* [path_readlink](#path_readlink)
+* [path_remove_directory](#path_remove_directory)
+* [path_rename](#path_rename)
+* [path_symlink](#path_symlink)
+* [path_unlink_file](#path_unlink_file)
+* [poll_oneoff](#poll_oneoff)
+* [proc_exit](#proc_exit)
+* [proc_raise](#proc_raise)
+* [random_get](#random_get)
+* [sched_yield](#sched_yield)
+* [sock_recv](#sock_recv)
+* [sock_send](#sock_send)
+* [sock_shutdown](#sock_shutdown)
+* [wasi_abort](#wasi_abort)
+
+## Type aliases
+
+###  aisize
+
+Ƭ **aisize**: *i32*
+
+*Defined in [assembly/as-wasi.ts:55](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L55)*
+
+___
+
+###  char
+
+Ƭ **char**: *u8*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:7
+
+___
+
+###  device
+
+Ƭ **device**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:631
+
+Identifier for a device containing a file system. Can be used in combination with `inode` to uniquely identify a file or directory in the filesystem.
+
+___
+
+###  dircookie
+
+Ƭ **dircookie**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:634
+
+A reference to the offset of a directory entry. The value 0 signifies the start of the directory.
+
+___
+
+###  exitcode
+
+Ƭ **exitcode**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1016
+
+Exit code generated by a process when exiting.
+
+___
+
+###  fd
+
+Ƭ **fd**: *u32*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1019
+
+A file descriptor number.
+
+___
+
+###  filedelta
+
+Ƭ **filedelta**: *i64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1059
+
+Relative offset within a file.
+
+___
+
+###  filesize
+
+Ƭ **filesize**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1062
+
+Non-negative file size or length of a region within a file.
+
+___
+
+###  inode
+
+Ƭ **inode**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1143
+
+File serial number that is unique within its file system.
+
+___
+
+###  linkcount
+
+Ƭ **linkcount**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1154
+
+Number of hard links to an inode.
+
+___
+
+###  ptr
+
+Ƭ **ptr**: *usize*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:8
+
+___
+
+###  struct
+
+Ƭ **struct**: *T*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:9
+
+___
+
+###  timestamp
+
+Ƭ **timestamp**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1545
+
+Timestamp in nanoseconds.
+
+___
+
+###  userdata
+
+Ƭ **userdata**: *u64*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1548
+
+User-provided value that may be attached to objects that is retained when extracted from the implementation.
+
+## Functions
+
+###  args_get
+
+▸ **args_get**(`argv`: [ptr](#ptr)‹[ptr](#ptr)‹[char](#char)››, `argv_buf`: [ptr](#ptr)‹[char](#char)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:14
+
+Read command-line argument data.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`argv` | [ptr](#ptr)‹[ptr](#ptr)‹[char](#char)›› |
+`argv_buf` | [ptr](#ptr)‹[char](#char)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  args_sizes_get
+
+▸ **args_sizes_get**(`argc`: [ptr](#ptr)‹usize›, `argv_buf_size`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:24
+
+Return command-line argument data sizes.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`argc` | [ptr](#ptr)‹usize› |
+`argv_buf_size` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  clock_res_get
+
+▸ **clock_res_get**(`clock`: [clockid](#modulesclockidmd), `resolution`: [ptr](#ptr)‹[timestamp](#timestamp)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:34
+
+Return the resolution of a clock.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`clock` | [clockid](#modulesclockidmd) |
+`resolution` | [ptr](#ptr)‹[timestamp](#timestamp)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  clock_time_get
+
+▸ **clock_time_get**(`clock`: [clockid](#modulesclockidmd), `precision`: [timestamp](#timestamp), `time`: [ptr](#ptr)‹[timestamp](#timestamp)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:44
+
+Return the time value of a clock.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`clock` | [clockid](#modulesclockidmd) |
+`precision` | [timestamp](#timestamp) |
+`time` | [ptr](#ptr)‹[timestamp](#timestamp)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  environ_get
+
+▸ **environ_get**(`environ`: [ptr](#ptr)‹usize›, `environ_buf`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:56
+
+Read environment variable data.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`environ` | [ptr](#ptr)‹usize› |
+`environ_buf` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  environ_sizes_get
+
+▸ **environ_sizes_get**(`environ_count`: [ptr](#ptr)‹usize›, `environ_buf_size`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:66
+
+Return command-line argument data sizes.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`environ_count` | [ptr](#ptr)‹usize› |
+`environ_buf_size` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_advise
+
+▸ **fd_advise**(`fd`: fd, `offset`: [filesize](#filesize), `len`: [filesize](#filesize), `advice`: advice): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:76
+
+Provide file advisory information on a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`offset` | [filesize](#filesize) |
+`len` | [filesize](#filesize) |
+`advice` | advice |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_allocate
+
+▸ **fd_allocate**(`fd`: fd, `offset`: [filesize](#filesize), `len`: [filesize](#filesize)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:90
+
+Provide file advisory information on a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`offset` | [filesize](#filesize) |
+`len` | [filesize](#filesize) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_close
+
+▸ **fd_close**(`fd`: fd): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:102
+
+Close a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_datasync
+
+▸ **fd_datasync**(`fd`: fd): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:110
+
+Synchronize the data of a file to disk.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_fdstat_get
+
+▸ **fd_fdstat_get**(`fd`: fd, `buf`: [struct](#struct)‹[fdstat](#classesfdstatmd)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:118
+
+Get the attributes of a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`buf` | [struct](#struct)‹[fdstat](#classesfdstatmd)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_fdstat_set_flags
+
+▸ **fd_fdstat_set_flags**(`fd`: fd, `flags`: [fdflags](#modulesfdflagsmd)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:128
+
+Adjust the flags associated with a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`flags` | [fdflags](#modulesfdflagsmd) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_fdstat_set_rights
+
+▸ **fd_fdstat_set_rights**(`fd`: fd, `fs_rights_base`: [rights](#modulesrightsmd), `fs_rights_inheriting`: [rights](#modulesrightsmd)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:138
+
+Adjust the rights associated with a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`fs_rights_base` | [rights](#modulesrightsmd) |
+`fs_rights_inheriting` | [rights](#modulesrightsmd) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_filestat_get
+
+▸ **fd_filestat_get**(`fd`: fd, `buf`: [struct](#struct)‹[filestat](#classesfilestatmd)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:150
+
+Return the attributes of an open file.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`buf` | [struct](#struct)‹[filestat](#classesfilestatmd)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_filestat_set_size
+
+▸ **fd_filestat_set_size**(`fd`: fd, `size`: [filesize](#filesize)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:160
+
+Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`size` | [filesize](#filesize) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_filestat_set_times
+
+▸ **fd_filestat_set_times**(`fd`: fd, `st_atim`: [timestamp](#timestamp), `st_mtim`: [timestamp](#timestamp), `fstflags`: fstflags): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:170
+
+Adjust the timestamps of an open file or directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`st_atim` | [timestamp](#timestamp) |
+`st_mtim` | [timestamp](#timestamp) |
+`fstflags` | fstflags |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_pread
+
+▸ **fd_pread**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `offset`: [filesize](#filesize), `nread`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:184
+
+Read from a file descriptor, without using and updating the file descriptor's offset.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`iovs_len` | usize |
+`offset` | [filesize](#filesize) |
+`nread` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_prestat_dir_name
+
+▸ **fd_prestat_dir_name**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:210
+
+Return a description of the given preopened file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_prestat_get
+
+▸ **fd_prestat_get**(`fd`: fd, `buf`: [struct](#struct)‹[prestat](#classesprestatmd)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:200
+
+Return a description of the given preopened file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`buf` | [struct](#struct)‹[prestat](#classesprestatmd)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_pwrite
+
+▸ **fd_pwrite**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `offset`: [filesize](#filesize), `nwritten`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:222
+
+Write to a file descriptor, without using and updating the file descriptor's offset.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`iovs_len` | usize |
+`offset` | [filesize](#filesize) |
+`nwritten` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_read
+
+▸ **fd_read**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `nread`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:238
+
+Read from a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`iovs_len` | usize |
+`nread` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_readdir
+
+▸ **fd_readdir**(`fd`: fd, `buf`: [ptr](#ptr)‹[struct](#struct)‹[dirent](#classesdirentmd)››, `buf_len`: usize, `cookie`: [dircookie](#dircookie), `buf_used`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:252
+
+Read directory entries from a directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`buf` | [ptr](#ptr)‹[struct](#struct)‹[dirent](#classesdirentmd)›› |
+`buf_len` | usize |
+`cookie` | [dircookie](#dircookie) |
+`buf_used` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_renumber
+
+▸ **fd_renumber**(`from`: fd, `to`: fd): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:268
+
+Atomically replace a file descriptor by renumbering another file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`from` | fd |
+`to` | fd |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_seek
+
+▸ **fd_seek**(`fd`: fd, `offset`: [filedelta](#filedelta), `whence`: whence, `newoffset`: [ptr](#ptr)‹[filesize](#filesize)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:278
+
+Move the offset of a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`offset` | [filedelta](#filedelta) |
+`whence` | whence |
+`newoffset` | [ptr](#ptr)‹[filesize](#filesize)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_sync
+
+▸ **fd_sync**(`fd`: fd): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:292
+
+Synchronize the data and metadata of a file to disk.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_tell
+
+▸ **fd_tell**(`fd`: fd, `newoffset`: [ptr](#ptr)‹[filesize](#filesize)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:300
+
+Return the current offset of a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`newoffset` | [ptr](#ptr)‹[filesize](#filesize)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  fd_write
+
+▸ **fd_write**(`fd`: fd, `iovs`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `iovs_len`: usize, `nwritten`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:310
+
+Write to a file descriptor.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`iovs` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`iovs_len` | usize |
+`nwritten` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_create_directory
+
+▸ **path_create_directory**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:324
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_filestat_get
+
+▸ **path_filestat_get**(`fd`: fd, `flags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `buf`: [struct](#struct)‹[filestat](#classesfilestatmd)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:336
+
+Return the attributes of a file or directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`flags` | [lookupflags](#moduleslookupflagsmd) |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+`buf` | [struct](#struct)‹[filestat](#classesfilestatmd)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_filestat_set_times
+
+▸ **path_filestat_set_times**(`fd`: fd, `flags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `st_atim`: [timestamp](#timestamp), `st_mtim`: [timestamp](#timestamp), `fstflags`: fstflags): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:352
+
+Adjust the timestamps of a file or directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`flags` | [lookupflags](#moduleslookupflagsmd) |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+`st_atim` | [timestamp](#timestamp) |
+`st_mtim` | [timestamp](#timestamp) |
+`fstflags` | fstflags |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_link
+
+▸ **path_link**(`old_fd`: fd, `old_flags`: [lookupflags](#moduleslookupflagsmd), `old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `new_fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:372
+
+Create a hard link.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_fd` | fd |
+`old_flags` | [lookupflags](#moduleslookupflagsmd) |
+`old_path` | [ptr](#ptr)‹[char](#char)› |
+`old_path_len` | usize |
+`new_fd` | fd |
+`new_path` | [ptr](#ptr)‹[char](#char)› |
+`new_path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_open
+
+▸ **path_open**(`dirfd`: fd, `dirflags`: [lookupflags](#moduleslookupflagsmd), `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `oflags`: oflags, `fs_rights_base`: [rights](#modulesrightsmd), `fs_rights_inheriting`: [rights](#modulesrightsmd), `fs_flags`: [fdflags](#modulesfdflagsmd), `fd`: [ptr](#ptr)‹fd›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:392
+
+Open a file or directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`dirfd` | fd |
+`dirflags` | [lookupflags](#moduleslookupflagsmd) |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+`oflags` | oflags |
+`fs_rights_base` | [rights](#modulesrightsmd) |
+`fs_rights_inheriting` | [rights](#modulesrightsmd) |
+`fs_flags` | [fdflags](#modulesfdflagsmd) |
+`fd` | [ptr](#ptr)‹fd› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_readlink
+
+▸ **path_readlink**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize, `buf`: [ptr](#ptr)‹[char](#char)›, `buf_len`: usize, `buf_used`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:416
+
+Read the contents of a symbolic link.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+`buf` | [ptr](#ptr)‹[char](#char)› |
+`buf_len` | usize |
+`buf_used` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_remove_directory
+
+▸ **path_remove_directory**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:434
+
+Remove a directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_rename
+
+▸ **path_rename**(`old_fd`: fd, `old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `new_fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:446
+
+Rename a file or directory.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_fd` | fd |
+`old_path` | [ptr](#ptr)‹[char](#char)› |
+`old_path_len` | usize |
+`new_fd` | fd |
+`new_path` | [ptr](#ptr)‹[char](#char)› |
+`new_path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_symlink
+
+▸ **path_symlink**(`old_path`: [ptr](#ptr)‹[char](#char)›, `old_path_len`: usize, `fd`: fd, `new_path`: [ptr](#ptr)‹[char](#char)›, `new_path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:464
+
+Create a symbolic link.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`old_path` | [ptr](#ptr)‹[char](#char)› |
+`old_path_len` | usize |
+`fd` | fd |
+`new_path` | [ptr](#ptr)‹[char](#char)› |
+`new_path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  path_unlink_file
+
+▸ **path_unlink_file**(`fd`: fd, `path`: [ptr](#ptr)‹[char](#char)›, `path_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:480
+
+Unlink a file.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`fd` | fd |
+`path` | [ptr](#ptr)‹[char](#char)› |
+`path_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  poll_oneoff
+
+▸ **poll_oneoff**(`in_`: [ptr](#ptr)‹[struct](#struct)‹[subscription](#classessubscriptionmd)››, `out`: [ptr](#ptr)‹[struct](#struct)‹[event](#classeseventmd)››, `nsubscriptions`: usize, `nevents`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:492
+
+Concurrently poll for the occurrence of a set of events.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`in_` | [ptr](#ptr)‹[struct](#struct)‹[subscription](#classessubscriptionmd)›› |
+`out` | [ptr](#ptr)‹[struct](#struct)‹[event](#classeseventmd)›› |
+`nsubscriptions` | usize |
+`nevents` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  proc_exit
+
+▸ **proc_exit**(`rval`: u32): *void*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:506
+
+Terminate the process normally. An exit code of 0 indicates successful termination of the program. The meanings of other values is dependent on the environment.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`rval` | u32 |
+
+**Returns:** *void*
+
+___
+
+###  proc_raise
+
+▸ **proc_raise**(`sig`: [signal](#modulessignalmd)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:514
+
+Send a signal to the process of the calling thread.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sig` | [signal](#modulessignalmd) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  random_get
+
+▸ **random_get**(`buf`: usize, `buf_len`: usize): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:522
+
+Write high-quality random data into a buffer.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`buf` | usize |
+`buf_len` | usize |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  sched_yield
+
+▸ **sched_yield**(): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:532
+
+Temporarily yield execution of the calling thread.
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  sock_recv
+
+▸ **sock_recv**(`sock`: fd, `ri_data`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `ri_data_len`: usize, `ri_flags`: [riflags](#modulesriflagsmd), `ro_datalen`: [ptr](#ptr)‹usize›, `ro_flags`: [ptr](#ptr)‹[roflags](#modulesroflagsmd)›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:537
+
+Receive a message from a socket.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sock` | fd |
+`ri_data` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`ri_data_len` | usize |
+`ri_flags` | [riflags](#modulesriflagsmd) |
+`ro_datalen` | [ptr](#ptr)‹usize› |
+`ro_flags` | [ptr](#ptr)‹[roflags](#modulesroflagsmd)› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  sock_send
+
+▸ **sock_send**(`sock`: fd, `si_data`: [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)››, `si_data_len`: usize, `si_flags`: [siflags](#modulessiflagsmd), `so_datalen`: [ptr](#ptr)‹usize›): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:555
+
+Send a message on a socket.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sock` | fd |
+`si_data` | [ptr](#ptr)‹[struct](#struct)‹[iovec](#classesiovecmd)›› |
+`si_data_len` | usize |
+`si_flags` | [siflags](#modulessiflagsmd) |
+`so_datalen` | [ptr](#ptr)‹usize› |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  sock_shutdown
+
+▸ **sock_shutdown**(`sock`: fd, `how`: [sdflags](#modulessdflagsmd)): *[errno](#moduleserrnomd)*
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:571
+
+Shut down socket send and receive channels.
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sock` | fd |
+`how` | [sdflags](#modulessdflagsmd) |
+
+**Returns:** *[errno](#moduleserrnomd)*
+
+___
+
+###  wasi_abort
+
+▸ **wasi_abort**(`message`: string, `fileName`: string, `lineNumber`: u32, `columnNumber`: u32): *void*
+
+*Defined in [assembly/as-wasi.ts:1034](https://github.com/torch2424/as-wasi/blob/5b6c28b/assembly/as-wasi.ts#L1034)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`message` | string | "" |
+`fileName` | string | "" |
+`lineNumber` | u32 | 0 |
+`columnNumber` | u32 | 0 |
+
+**Returns:** *void*
+
+# Modules
+
+
+<a name="modulesadvicemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [advice](#modulesadvicemd)
+
+## Namespace: advice
+
+File or memory access pattern advisory information.
+
+### Index
+
+#### Variables
+
+* [DONTNEED](#const-dontneed)
+* [NOREUSE](#const-noreuse)
+* [NORMAL](#const-normal)
+* [RANDOM](#const-random)
+* [SEQUENTIAL](#const-sequential)
+* [WILLNEED](#const-willneed)
+
+### Variables
+
+#### `Const` DONTNEED
+
+• **DONTNEED**: *advice* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:601
+
+The application expects that it will not access the specified data in the near future.
+
+___
+
+#### `Const` NOREUSE
+
+• **NOREUSE**: *advice* = 5
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:605
+
+The application expects to access the specified data once and then not reuse it thereafter.
+
+___
+
+#### `Const` NORMAL
+
+• **NORMAL**: *advice* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:585
+
+The application has no advice to give on its behavior with respect to the specified data.
+
+___
+
+#### `Const` RANDOM
+
+• **RANDOM**: *advice* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:593
+
+The application expects to access the specified data in a random order.
+
+___
+
+#### `Const` SEQUENTIAL
+
+• **SEQUENTIAL**: *advice* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:589
+
+The application expects to access the specified data sequentially from lower offsets to higher offsets.
+
+___
+
+#### `Const` WILLNEED
+
+• **WILLNEED**: *advice* = 3
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:597
+
+The application expects to access the specified data in the near future.
+
+
+<a name="modulesclockidmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [clockid](#modulesclockidmd)
+
+## Namespace: clockid
+
+Identifiers for clocks.
+
+### Index
+
+#### Variables
+
+* [MONOTONIC](#const-monotonic)
+* [PROCESS_CPUTIME_ID](#const-process_cputime_id)
+* [REALTIME](#const-realtime)
+* [THREAD_CPUTIME_ID](#const-thread_cputime_id)
+
+### Variables
+
+#### `Const` MONOTONIC
+
+• **MONOTONIC**: *[clockid](#modulesclockidmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:618
+
+The store-wide monotonic clock. Absolute value has no meaning.
+
+___
+
+#### `Const` PROCESS_CPUTIME_ID
+
+• **PROCESS_CPUTIME_ID**: *[clockid](#modulesclockidmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:622
+
+The CPU-time clock associated with the current process.
+
+___
+
+#### `Const` REALTIME
+
+• **REALTIME**: *[clockid](#modulesclockidmd)* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:614
+
+The clock measuring real time. Time value zero corresponds with 1970-01-01T00:00:00Z.
+
+___
+
+#### `Const` THREAD_CPUTIME_ID
+
+• **THREAD_CPUTIME_ID**: *[clockid](#modulesclockidmd)* = 3
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:626
+
+The CPU-time clock associated with the current thread.
+
+
+<a name="moduleserrnomd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [errno](#moduleserrnomd)
+
+## Namespace: errno
+
+Error codes returned by functions.
+
+### Index
+
+#### Variables
+
+* [ACCES](#const-acces)
+* [ADDRINUSE](#const-addrinuse)
+* [ADDRNOTAVAIL](#const-addrnotavail)
+* [AFNOSUPPORT](#const-afnosupport)
+* [AGAIN](#const-again)
+* [ALREADY](#const-already)
+* [BADF](#const-badf)
+* [BADMSG](#const-badmsg)
+* [BUSY](#const-busy)
+* [CANCELED](#const-canceled)
+* [CHILD](#const-child)
+* [CONNABORTED](#const-connaborted)
+* [CONNREFUSED](#const-connrefused)
+* [CONNRESET](#const-connreset)
+* [DEADLK](#const-deadlk)
+* [DESTADDRREQ](#const-destaddrreq)
+* [DOM](#const-dom)
+* [DQUOT](#const-dquot)
+* [EXIST](#const-exist)
+* [FAULT](#const-fault)
+* [FBIG](#const-fbig)
+* [HOSTUNREACH](#const-hostunreach)
+* [IDRM](#const-idrm)
+* [ILSEQ](#const-ilseq)
+* [INPROGRESS](#const-inprogress)
+* [INTR](#const-intr)
+* [INVAL](#const-inval)
+* [IO](#const-io)
+* [ISCONN](#const-isconn)
+* [ISDIR](#const-isdir)
+* [LOOP](#const-loop)
+* [MFILE](#const-mfile)
+* [MLINK](#const-mlink)
+* [MSGSIZE](#const-msgsize)
+* [MULTIHOP](#const-multihop)
+* [NAMETOOLONG](#const-nametoolong)
+* [NETDOWN](#const-netdown)
+* [NETRESET](#const-netreset)
+* [NETUNREACH](#const-netunreach)
+* [NFILE](#const-nfile)
+* [NOBUFS](#const-nobufs)
+* [NODEV](#const-nodev)
+* [NOENT](#const-noent)
+* [NOEXEC](#const-noexec)
+* [NOLCK](#const-nolck)
+* [NOLINK](#const-nolink)
+* [NOMEM](#const-nomem)
+* [NOMSG](#const-nomsg)
+* [NOPROTOOPT](#const-noprotoopt)
+* [NOSPC](#const-nospc)
+* [NOSYS](#const-nosys)
+* [NOTCAPABLE](#const-notcapable)
+* [NOTCONN](#const-notconn)
+* [NOTDIR](#const-notdir)
+* [NOTEMPTY](#const-notempty)
+* [NOTRECOVERABLE](#const-notrecoverable)
+* [NOTSOCK](#const-notsock)
+* [NOTSUP](#const-notsup)
+* [NOTTY](#const-notty)
+* [NXIO](#const-nxio)
+* [OVERFLOW](#const-overflow)
+* [OWNERDEAD](#const-ownerdead)
+* [PERM](#const-perm)
+* [PIPE](#const-pipe)
+* [PROTO](#const-proto)
+* [PROTONOSUPPORT](#const-protonosupport)
+* [PROTOTYPE](#const-prototype)
+* [RANGE](#const-range)
+* [ROFS](#const-rofs)
+* [SPIPE](#const-spipe)
+* [SRCH](#const-srch)
+* [STALE](#const-stale)
+* [SUCCESS](#const-success)
+* [TIMEDOUT](#const-timedout)
+* [TOOBIG](#const-toobig)
+* [TXTBSY](#const-txtbsy)
+* [XDEV](#const-xdev)
+
+### Variables
+
+#### `Const` ACCES
+
+• **ACCES**: *[errno](#moduleserrnomd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:662
+
+Permission denied.
+
+___
+
+#### `Const` ADDRINUSE
+
+• **ADDRINUSE**: *[errno](#moduleserrnomd)* = 3
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:666
+
+Address in use.
+
+___
+
+#### `Const` ADDRNOTAVAIL
+
+• **ADDRNOTAVAIL**: *[errno](#moduleserrnomd)* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:670
+
+Address not available.
+
+___
+
+#### `Const` AFNOSUPPORT
+
+• **AFNOSUPPORT**: *[errno](#moduleserrnomd)* = 5
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:674
+
+Address family not supported.
+
+___
+
+#### `Const` AGAIN
+
+• **AGAIN**: *[errno](#moduleserrnomd)* = 6
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:678
+
+Resource unavailable, or operation would block.
+
+___
+
+#### `Const` ALREADY
+
+• **ALREADY**: *[errno](#moduleserrnomd)* = 7
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:682
+
+Connection already in progress.
+
+___
+
+#### `Const` BADF
+
+• **BADF**: *[errno](#moduleserrnomd)* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:686
+
+Bad file descriptor.
+
+___
+
+#### `Const` BADMSG
+
+• **BADMSG**: *[errno](#moduleserrnomd)* = 9
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:690
+
+Bad message.
+
+___
+
+#### `Const` BUSY
+
+• **BUSY**: *[errno](#moduleserrnomd)* = 10
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:694
+
+Device or resource busy.
+
+___
+
+#### `Const` CANCELED
+
+• **CANCELED**: *[errno](#moduleserrnomd)* = 11
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:698
+
+Operation canceled.
+
+___
+
+#### `Const` CHILD
+
+• **CHILD**: *[errno](#moduleserrnomd)* = 12
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:702
+
+No child processes.
+
+___
+
+#### `Const` CONNABORTED
+
+• **CONNABORTED**: *[errno](#moduleserrnomd)* = 13
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:706
+
+Connection aborted.
+
+___
+
+#### `Const` CONNREFUSED
+
+• **CONNREFUSED**: *[errno](#moduleserrnomd)* = 14
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:710
+
+Connection refused.
+
+___
+
+#### `Const` CONNRESET
+
+• **CONNRESET**: *[errno](#moduleserrnomd)* = 15
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:714
+
+Connection reset.
+
+___
+
+#### `Const` DEADLK
+
+• **DEADLK**: *[errno](#moduleserrnomd)* = 16
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:718
+
+Resource deadlock would occur.
+
+___
+
+#### `Const` DESTADDRREQ
+
+• **DESTADDRREQ**: *[errno](#moduleserrnomd)* = 17
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:722
+
+Destination address required.
+
+___
+
+#### `Const` DOM
+
+• **DOM**: *[errno](#moduleserrnomd)* = 18
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:726
+
+Mathematics argument out of domain of function.
+
+___
+
+#### `Const` DQUOT
+
+• **DQUOT**: *[errno](#moduleserrnomd)* = 19
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:730
+
+Reserved.
+
+___
+
+#### `Const` EXIST
+
+• **EXIST**: *[errno](#moduleserrnomd)* = 20
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:734
+
+File exists.
+
+___
+
+#### `Const` FAULT
+
+• **FAULT**: *[errno](#moduleserrnomd)* = 21
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:738
+
+Bad address.
+
+___
+
+#### `Const` FBIG
+
+• **FBIG**: *[errno](#moduleserrnomd)* = 22
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:742
+
+File too large.
+
+___
+
+#### `Const` HOSTUNREACH
+
+• **HOSTUNREACH**: *[errno](#moduleserrnomd)* = 23
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:746
+
+Host is unreachable.
+
+___
+
+#### `Const` IDRM
+
+• **IDRM**: *[errno](#moduleserrnomd)* = 24
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:750
+
+Identifier removed.
+
+___
+
+#### `Const` ILSEQ
+
+• **ILSEQ**: *[errno](#moduleserrnomd)* = 25
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:754
+
+Illegal byte sequence.
+
+___
+
+#### `Const` INPROGRESS
+
+• **INPROGRESS**: *[errno](#moduleserrnomd)* = 26
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:758
+
+Operation in progress.
+
+___
+
+#### `Const` INTR
+
+• **INTR**: *[errno](#moduleserrnomd)* = 27
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:762
+
+Interrupted function.
+
+___
+
+#### `Const` INVAL
+
+• **INVAL**: *[errno](#moduleserrnomd)* = 28
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:766
+
+Invalid argument.
+
+___
+
+#### `Const` IO
+
+• **IO**: *[errno](#moduleserrnomd)* = 29
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:770
+
+I/O error.
+
+___
+
+#### `Const` ISCONN
+
+• **ISCONN**: *[errno](#moduleserrnomd)* = 30
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:774
+
+Socket is connected.
+
+___
+
+#### `Const` ISDIR
+
+• **ISDIR**: *[errno](#moduleserrnomd)* = 31
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:778
+
+Is a directory.
+
+___
+
+#### `Const` LOOP
+
+• **LOOP**: *[errno](#moduleserrnomd)* = 32
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:782
+
+Too many levels of symbolic links.
+
+___
+
+#### `Const` MFILE
+
+• **MFILE**: *[errno](#moduleserrnomd)* = 33
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:786
+
+File descriptor value too large.
+
+___
+
+#### `Const` MLINK
+
+• **MLINK**: *[errno](#moduleserrnomd)* = 34
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:790
+
+Too many links.
+
+___
+
+#### `Const` MSGSIZE
+
+• **MSGSIZE**: *[errno](#moduleserrnomd)* = 35
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:794
+
+Message too large.
+
+___
+
+#### `Const` MULTIHOP
+
+• **MULTIHOP**: *[errno](#moduleserrnomd)* = 36
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:798
+
+Reserved.
+
+___
+
+#### `Const` NAMETOOLONG
+
+• **NAMETOOLONG**: *[errno](#moduleserrnomd)* = 37
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:802
+
+Filename too long.
+
+___
+
+#### `Const` NETDOWN
+
+• **NETDOWN**: *[errno](#moduleserrnomd)* = 38
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:806
+
+Network is down.
+
+___
+
+#### `Const` NETRESET
+
+• **NETRESET**: *[errno](#moduleserrnomd)* = 39
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:810
+
+Connection aborted by network.
+
+___
+
+#### `Const` NETUNREACH
+
+• **NETUNREACH**: *[errno](#moduleserrnomd)* = 40
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:814
+
+Network unreachable.
+
+___
+
+#### `Const` NFILE
+
+• **NFILE**: *[errno](#moduleserrnomd)* = 41
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:818
+
+Too many files open in system.
+
+___
+
+#### `Const` NOBUFS
+
+• **NOBUFS**: *[errno](#moduleserrnomd)* = 42
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:822
+
+No buffer space available.
+
+___
+
+#### `Const` NODEV
+
+• **NODEV**: *[errno](#moduleserrnomd)* = 43
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:826
+
+No such device.
+
+___
+
+#### `Const` NOENT
+
+• **NOENT**: *[errno](#moduleserrnomd)* = 44
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:830
+
+No such file or directory.
+
+___
+
+#### `Const` NOEXEC
+
+• **NOEXEC**: *[errno](#moduleserrnomd)* = 45
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:834
+
+Executable file format error.
+
+___
+
+#### `Const` NOLCK
+
+• **NOLCK**: *[errno](#moduleserrnomd)* = 46
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:838
+
+No locks available.
+
+___
+
+#### `Const` NOLINK
+
+• **NOLINK**: *[errno](#moduleserrnomd)* = 47
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:842
+
+Reserved.
+
+___
+
+#### `Const` NOMEM
+
+• **NOMEM**: *[errno](#moduleserrnomd)* = 48
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:846
+
+Not enough space.
+
+___
+
+#### `Const` NOMSG
+
+• **NOMSG**: *[errno](#moduleserrnomd)* = 49
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:850
+
+No message of the desired type.
+
+___
+
+#### `Const` NOPROTOOPT
+
+• **NOPROTOOPT**: *[errno](#moduleserrnomd)* = 50
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:854
+
+Protocol not available.
+
+___
+
+#### `Const` NOSPC
+
+• **NOSPC**: *[errno](#moduleserrnomd)* = 51
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:858
+
+No space left on device.
+
+___
+
+#### `Const` NOSYS
+
+• **NOSYS**: *[errno](#moduleserrnomd)* = 52
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:862
+
+Function not supported.
+
+___
+
+#### `Const` NOTCAPABLE
+
+• **NOTCAPABLE**: *[errno](#moduleserrnomd)* = 76
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:958
+
+Extension: Capabilities insufficient.
+
+___
+
+#### `Const` NOTCONN
+
+• **NOTCONN**: *[errno](#moduleserrnomd)* = 53
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:866
+
+The socket is not connected.
+
+___
+
+#### `Const` NOTDIR
+
+• **NOTDIR**: *[errno](#moduleserrnomd)* = 54
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:870
+
+Not a directory or a symbolic link to a directory.
+
+___
+
+#### `Const` NOTEMPTY
+
+• **NOTEMPTY**: *[errno](#moduleserrnomd)* = 55
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:874
+
+Directory not empty.
+
+___
+
+#### `Const` NOTRECOVERABLE
+
+• **NOTRECOVERABLE**: *[errno](#moduleserrnomd)* = 56
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:878
+
+State not recoverable.
+
+___
+
+#### `Const` NOTSOCK
+
+• **NOTSOCK**: *[errno](#moduleserrnomd)* = 57
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:882
+
+Not a socket.
+
+___
+
+#### `Const` NOTSUP
+
+• **NOTSUP**: *[errno](#moduleserrnomd)* = 58
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:886
+
+Not supported, or operation not supported on socket.
+
+___
+
+#### `Const` NOTTY
+
+• **NOTTY**: *[errno](#moduleserrnomd)* = 59
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:890
+
+Inappropriate I/O control operation.
+
+___
+
+#### `Const` NXIO
+
+• **NXIO**: *[errno](#moduleserrnomd)* = 60
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:894
+
+No such device or address.
+
+___
+
+#### `Const` OVERFLOW
+
+• **OVERFLOW**: *[errno](#moduleserrnomd)* = 61
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:898
+
+Value too large to be stored in data type.
+
+___
+
+#### `Const` OWNERDEAD
+
+• **OWNERDEAD**: *[errno](#moduleserrnomd)* = 62
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:902
+
+Previous owner died.
+
+___
+
+#### `Const` PERM
+
+• **PERM**: *[errno](#moduleserrnomd)* = 63
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:906
+
+Operation not permitted.
+
+___
+
+#### `Const` PIPE
+
+• **PIPE**: *[errno](#moduleserrnomd)* = 64
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:910
+
+Broken pipe.
+
+___
+
+#### `Const` PROTO
+
+• **PROTO**: *[errno](#moduleserrnomd)* = 65
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:914
+
+Protocol error.
+
+___
+
+#### `Const` PROTONOSUPPORT
+
+• **PROTONOSUPPORT**: *[errno](#moduleserrnomd)* = 66
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:918
+
+Protocol not supported.
+
+___
+
+#### `Const` PROTOTYPE
+
+• **PROTOTYPE**: *[errno](#moduleserrnomd)* = 67
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:922
+
+Protocol wrong type for socket.
+
+___
+
+#### `Const` RANGE
+
+• **RANGE**: *[errno](#moduleserrnomd)* = 68
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:926
+
+Result too large.
+
+___
+
+#### `Const` ROFS
+
+• **ROFS**: *[errno](#moduleserrnomd)* = 69
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:930
+
+Read-only file system.
+
+___
+
+#### `Const` SPIPE
+
+• **SPIPE**: *[errno](#moduleserrnomd)* = 70
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:934
+
+Invalid seek.
+
+___
+
+#### `Const` SRCH
+
+• **SRCH**: *[errno](#moduleserrnomd)* = 71
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:938
+
+No such process.
+
+___
+
+#### `Const` STALE
+
+• **STALE**: *[errno](#moduleserrnomd)* = 72
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:942
+
+Reserved.
+
+___
+
+#### `Const` SUCCESS
+
+• **SUCCESS**: *[errno](#moduleserrnomd)* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:654
+
+No error occurred. System call completed successfully.
+
+___
+
+#### `Const` TIMEDOUT
+
+• **TIMEDOUT**: *[errno](#moduleserrnomd)* = 73
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:946
+
+Connection timed out.
+
+___
+
+#### `Const` TOOBIG
+
+• **TOOBIG**: *[errno](#moduleserrnomd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:658
+
+Argument list too long.
+
+___
+
+#### `Const` TXTBSY
+
+• **TXTBSY**: *[errno](#moduleserrnomd)* = 74
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:950
+
+Text file busy.
+
+___
+
+#### `Const` XDEV
+
+• **XDEV**: *[errno](#moduleserrnomd)* = 75
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:954
+
+Cross-device link.
+
+
+<a name="moduleseventrwflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [eventrwflags](#moduleseventrwflagsmd)
+
+## Namespace: eventrwflags
+
+The state of the file descriptor subscribed to with `eventtype.FD_READ` or `eventtype.FD_WRITE`.
+
+### Index
+
+#### Variables
+
+* [HANGUP](#const-hangup)
+
+### Variables
+
+#### `Const` HANGUP
+
+• **HANGUP**: *[eventrwflags](#moduleseventrwflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:994
+
+The peer of this socket has closed or disconnected.
+
+
+<a name="moduleseventtypemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [eventtype](#moduleseventtypemd)
+
+## Namespace: eventtype
+
+Type of a subscription to an event or its occurrence.
+
+### Index
+
+#### Variables
+
+* [CLOCK](#const-clock)
+* [FD_READ](#const-fd_read)
+* [FD_WRITE](#const-fd_write)
+
+### Variables
+
+#### `Const` CLOCK
+
+• **CLOCK**: *[eventtype](#moduleseventtypemd)* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1003
+
+The time value of clock has reached the timestamp.
+
+___
+
+#### `Const` FD_READ
+
+• **FD_READ**: *[eventtype](#moduleseventtypemd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1007
+
+File descriptor has data available for reading.
+
+___
+
+#### `Const` FD_WRITE
+
+• **FD_WRITE**: *[eventtype](#moduleseventtypemd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1011
+
+File descriptor has capacity available for writing
+
+
+<a name="modulesfdflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fdflags](#modulesfdflagsmd)
+
+## Namespace: fdflags
+
+File descriptor flags.
+
+### Index
+
+#### Variables
+
+* [APPEND](#const-append)
+* [DSYNC](#const-dsync)
+* [NONBLOCK](#const-nonblock)
+* [RSYNC](#const-rsync)
+* [SYNC](#const-sync)
+
+### Variables
+
+#### `Const` APPEND
+
+• **APPEND**: *[fdflags](#modulesfdflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1026
+
+Append mode: Data written to the file is always appended to the file's end.
+
+___
+
+#### `Const` DSYNC
+
+• **DSYNC**: *[fdflags](#modulesfdflagsmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1030
+
+Write according to synchronized I/O data integrity completion. Only the data stored in the file is synchronized.
+
+___
+
+#### `Const` NONBLOCK
+
+• **NONBLOCK**: *[fdflags](#modulesfdflagsmd)* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1034
+
+Non-blocking mode.
+
+___
+
+#### `Const` RSYNC
+
+• **RSYNC**: *[fdflags](#modulesfdflagsmd)* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1038
+
+Synchronized read I/O operations.
+
+___
+
+#### `Const` SYNC
+
+• **SYNC**: *[fdflags](#modulesfdflagsmd)* = 16
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1042
+
+Write according to synchronized I/O file integrity completion.
+
+
+<a name="modulesfiletypemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [filetype](#modulesfiletypemd)
+
+## Namespace: filetype
+
+The type of a file descriptor or file.
+
+### Index
+
+#### Variables
+
+* [BLOCK_DEVICE](#const-block_device)
+* [CHARACTER_DEVICE](#const-character_device)
+* [DIRECTORY](#const-directory)
+* [REGULAR_FILE](#const-regular_file)
+* [SOCKET_DGRAM](#const-socket_dgram)
+* [SOCKET_STREAM](#const-socket_stream)
+* [SYMBOLIC_LINK](#const-symbolic_link)
+* [UNKNOWN](#const-unknown)
+
+### Variables
+
+#### `Const` BLOCK_DEVICE
+
+• **BLOCK_DEVICE**: *[filetype](#filetype)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1093
+
+The file descriptor or file refers to a block device inode.
+
+___
+
+#### `Const` CHARACTER_DEVICE
+
+• **CHARACTER_DEVICE**: *[filetype](#filetype)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1097
+
+The file descriptor or file refers to a character device inode.
+
+___
+
+#### `Const` DIRECTORY
+
+• **DIRECTORY**: *[filetype](#filetype)* = 3
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1101
+
+The file descriptor or file refers to a directory inode.
+
+___
+
+#### `Const` REGULAR_FILE
+
+• **REGULAR_FILE**: *[filetype](#filetype)* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1105
+
+The file descriptor or file refers to a regular file inode.
+
+___
+
+#### `Const` SOCKET_DGRAM
+
+• **SOCKET_DGRAM**: *[filetype](#filetype)* = 5
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1109
+
+The file descriptor or file refers to a datagram socket.
+
+___
+
+#### `Const` SOCKET_STREAM
+
+• **SOCKET_STREAM**: *[filetype](#filetype)* = 6
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1113
+
+The file descriptor or file refers to a byte-stream socket.
+
+___
+
+#### `Const` SYMBOLIC_LINK
+
+• **SYMBOLIC_LINK**: *[filetype](#filetype)* = 7
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1117
+
+The file refers to a symbolic link inode.
+
+___
+
+#### `Const` UNKNOWN
+
+• **UNKNOWN**: *[filetype](#filetype)* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1089
+
+The type of the file descriptor or file is unknown or is different from any of the other types specified.
+
+
+<a name="modulesfstflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [fstflags](#modulesfstflagsmd)
+
+## Namespace: fstflags
+
+Which file time attributes to adjust.
+
+### Index
+
+#### Variables
+
+* [SET_ATIM](#const-set_atim)
+* [SET_ATIM_NOW](#const-set_atim_now)
+* [SET_MTIM](#const-set_mtim)
+* [SET_MTIM_NOW](#const-set_mtim_now)
+
+### Variables
+
+#### `Const` SET_ATIM
+
+• **SET_ATIM**: *fstflags* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1126
+
+Adjust the last data access timestamp to the value stored in `filestat#st_atim`.
+
+___
+
+#### `Const` SET_ATIM_NOW
+
+• **SET_ATIM_NOW**: *fstflags* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1130
+
+Adjust the last data access timestamp to the time of clock `clockid.REALTIME`.
+
+___
+
+#### `Const` SET_MTIM
+
+• **SET_MTIM**: *fstflags* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1134
+
+Adjust the last data modification timestamp to the value stored in `filestat#st_mtim`.
+
+___
+
+#### `Const` SET_MTIM_NOW
+
+• **SET_MTIM_NOW**: *fstflags* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1138
+
+Adjust the last data modification timestamp to the time of clock `clockid.REALTIME`.
+
+
+<a name="moduleslookupflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [lookupflags](#moduleslookupflagsmd)
+
+## Namespace: lookupflags
+
+Flags determining the method of how paths are resolved.
+
+### Index
+
+#### Variables
+
+* [SYMLINK_FOLLOW](#const-symlink_follow)
+
+### Variables
+
+#### `Const` SYMLINK_FOLLOW
+
+• **SYMLINK_FOLLOW**: *[lookupflags](#moduleslookupflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1161
+
+As long as the resolved path corresponds to a symbolic link, it is expanded.
+
+
+<a name="modulesoflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [oflags](#modulesoflagsmd)
+
+## Namespace: oflags
+
+Open flags.
+
+### Index
+
+#### Variables
+
+* [CREAT](#const-creat)
+* [DIRECTORY](#const-directory)
+* [EXCL](#const-excl)
+* [TRUNC](#const-trunc)
+
+### Variables
+
+#### `Const` CREAT
+
+• **CREAT**: *oflags* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1170
+
+Create file if it does not exist.
+
+___
+
+#### `Const` DIRECTORY
+
+• **DIRECTORY**: *oflags* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1174
+
+Fail if not a directory.
+
+___
+
+#### `Const` EXCL
+
+• **EXCL**: *oflags* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1178
+
+Fail if file already exists.
+
+___
+
+#### `Const` TRUNC
+
+• **TRUNC**: *oflags* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1182
+
+Truncate file to size 0.
+
+
+<a name="modulespreopentypemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [preopentype](#modulespreopentypemd)
+
+## Namespace: preopentype
+
+Identifiers for preopened capabilities.
+
+### Index
+
+#### Variables
+
+* [DIR](#const-dir)
+
+### Variables
+
+#### `Const` DIR
+
+• **DIR**: *[preopentype](#modulespreopentypemd)* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1191
+
+A pre-opened directory.
+
+
+<a name="modulesriflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [riflags](#modulesriflagsmd)
+
+## Namespace: riflags
+
+Flags provided to `sock_recv`.
+
+### Index
+
+#### Variables
+
+* [PEEK](#const-peek)
+* [WAITALL](#const-waitall)
+
+### Variables
+
+#### `Const` PEEK
+
+• **PEEK**: *[riflags](#modulesriflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1216
+
+Returns the message without removing it from the socket's receive queue.
+
+___
+
+#### `Const` WAITALL
+
+• **WAITALL**: *[riflags](#modulesriflagsmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1220
+
+On byte-stream sockets, block until the full amount of data can be returned.
+
+
+<a name="modulesrightsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [rights](#modulesrightsmd)
+
+## Namespace: rights
+
+File descriptor rights, determining which actions may be performed.
+
+### Index
+
+#### Variables
+
+* [FD_ADVISE](#const-fd_advise)
+* [FD_ALLOCATE](#const-fd_allocate)
+* [FD_DATASYNC](#const-fd_datasync)
+* [FD_FDSTAT_SET_FLAGS](#const-fd_fdstat_set_flags)
+* [FD_FILESTAT_GET](#const-fd_filestat_get)
+* [FD_FILESTAT_SET_SIZE](#const-fd_filestat_set_size)
+* [FD_FILESTAT_SET_TIMES](#const-fd_filestat_set_times)
+* [FD_READ](#const-fd_read)
+* [FD_READDIR](#const-fd_readdir)
+* [FD_SEEK](#const-fd_seek)
+* [FD_SYNC](#const-fd_sync)
+* [FD_TELL](#const-fd_tell)
+* [FD_WRITE](#const-fd_write)
+* [PATH_CREATE_DIRECTORY](#const-path_create_directory)
+* [PATH_CREATE_FILE](#const-path_create_file)
+* [PATH_FILESTAT_GET](#const-path_filestat_get)
+* [PATH_FILESTAT_SET_SIZE](#const-path_filestat_set_size)
+* [PATH_FILESTAT_SET_TIMES](#const-path_filestat_set_times)
+* [PATH_LINK_SOURCE](#const-path_link_source)
+* [PATH_LINK_TARGET](#const-path_link_target)
+* [PATH_OPEN](#const-path_open)
+* [PATH_READLINK](#const-path_readlink)
+* [PATH_REMOVE_DIRECTORY](#const-path_remove_directory)
+* [PATH_RENAME_SOURCE](#const-path_rename_source)
+* [PATH_RENAME_TARGET](#const-path_rename_target)
+* [PATH_UNLINK_FILE](#const-path_unlink_file)
+* [POLL_FD_READWRITE](#const-poll_fd_readwrite)
+* [RIGHT_PATH_SYMLINK](#const-right_path_symlink)
+* [SOCK_SHUTDOWN](#const-sock_shutdown)
+
+### Variables
+
+#### `Const` FD_ADVISE
+
+• **FD_ADVISE**: *[rights](#modulesrightsmd)* = 128
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1257
+
+The right to invoke `fd_advise`.
+
+___
+
+#### `Const` FD_ALLOCATE
+
+• **FD_ALLOCATE**: *[rights](#modulesrightsmd)* = 256
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1261
+
+The right to invoke `fd_allocate`.
+
+___
+
+#### `Const` FD_DATASYNC
+
+• **FD_DATASYNC**: *[rights](#modulesrightsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1229
+
+The right to invoke `fd_datasync`.
+
+___
+
+#### `Const` FD_FDSTAT_SET_FLAGS
+
+• **FD_FDSTAT_SET_FLAGS**: *[rights](#modulesrightsmd)* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1241
+
+The right to invoke `fd_fdstat_set_flags`.
+
+___
+
+#### `Const` FD_FILESTAT_GET
+
+• **FD_FILESTAT_GET**: *[rights](#modulesrightsmd)* = 2097152
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1313
+
+The right to invoke `fd_filestat_get`.
+
+___
+
+#### `Const` FD_FILESTAT_SET_SIZE
+
+• **FD_FILESTAT_SET_SIZE**: *[rights](#modulesrightsmd)* = 4194304
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1317
+
+The right to invoke `fd_filestat_set_size`.
+
+___
+
+#### `Const` FD_FILESTAT_SET_TIMES
+
+• **FD_FILESTAT_SET_TIMES**: *[rights](#modulesrightsmd)* = 8388608
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1321
+
+The right to invoke `fd_filestat_set_times`.
+
+___
+
+#### `Const` FD_READ
+
+• **FD_READ**: *[rights](#modulesrightsmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1233
+
+The right to invoke `fd_read` and `sock_recv`.
+
+___
+
+#### `Const` FD_READDIR
+
+• **FD_READDIR**: *[rights](#modulesrightsmd)* = 16384
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1285
+
+The right to invoke `fd_readdir`.
+
+___
+
+#### `Const` FD_SEEK
+
+• **FD_SEEK**: *[rights](#modulesrightsmd)* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1237
+
+The right to invoke `fd_seek`. This flag implies `rights.FD_TELL`.
+
+___
+
+#### `Const` FD_SYNC
+
+• **FD_SYNC**: *[rights](#modulesrightsmd)* = 16
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1245
+
+The right to invoke `fd_sync`.
+
+___
+
+#### `Const` FD_TELL
+
+• **FD_TELL**: *[rights](#modulesrightsmd)* = 32
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1249
+
+The right to invoke `fd_seek` in such a way that the file offset remains unaltered (i.e., `whence.CUR` with offset zero), or to invoke `fd_tell`).
+
+___
+
+#### `Const` FD_WRITE
+
+• **FD_WRITE**: *[rights](#modulesrightsmd)* = 64
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1253
+
+The right to invoke `fd_write` and `sock_send`. If `rights.FD_SEEK` is set, includes the right to invoke `fd_pwrite`.
+
+___
+
+#### `Const` PATH_CREATE_DIRECTORY
+
+• **PATH_CREATE_DIRECTORY**: *[rights](#modulesrightsmd)* = 512
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1265
+
+The right to invoke `path_create_directory`.
+
+___
+
+#### `Const` PATH_CREATE_FILE
+
+• **PATH_CREATE_FILE**: *[rights](#modulesrightsmd)* = 1024
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1269
+
+If `rights.PATH_OPEN` is set, the right to invoke `path_open` with `oflags.CREAT`.
+
+___
+
+#### `Const` PATH_FILESTAT_GET
+
+• **PATH_FILESTAT_GET**: *[rights](#modulesrightsmd)* = 262144
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1301
+
+The right to invoke `path_filestat_get`.
+
+___
+
+#### `Const` PATH_FILESTAT_SET_SIZE
+
+• **PATH_FILESTAT_SET_SIZE**: *[rights](#modulesrightsmd)* = 524288
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1305
+
+The right to change a file's size (there is no `path_filestat_set_size`). If `rights.PATH_OPEN` is set, includes the right to invoke `path_open` with `oflags.TRUNC`.
+
+___
+
+#### `Const` PATH_FILESTAT_SET_TIMES
+
+• **PATH_FILESTAT_SET_TIMES**: *[rights](#modulesrightsmd)* = 1048576
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1309
+
+The right to invoke `path_filestat_set_times`.
+
+___
+
+#### `Const` PATH_LINK_SOURCE
+
+• **PATH_LINK_SOURCE**: *[rights](#modulesrightsmd)* = 2048
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1273
+
+The right to invoke `path_link` with the file descriptor as the source directory.
+
+___
+
+#### `Const` PATH_LINK_TARGET
+
+• **PATH_LINK_TARGET**: *[rights](#modulesrightsmd)* = 4096
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1277
+
+The right to invoke `path_link` with the file descriptor as the target directory.
+
+___
+
+#### `Const` PATH_OPEN
+
+• **PATH_OPEN**: *[rights](#modulesrightsmd)* = 8192
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1281
+
+The right to invoke `path_open`.
+
+___
+
+#### `Const` PATH_READLINK
+
+• **PATH_READLINK**: *[rights](#modulesrightsmd)* = 32768
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1289
+
+The right to invoke `path_readlink`.
+
+___
+
+#### `Const` PATH_REMOVE_DIRECTORY
+
+• **PATH_REMOVE_DIRECTORY**: *[rights](#modulesrightsmd)* = 33554432
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1329
+
+The right to invoke `path_remove_directory`.
+
+___
+
+#### `Const` PATH_RENAME_SOURCE
+
+• **PATH_RENAME_SOURCE**: *[rights](#modulesrightsmd)* = 65536
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1293
+
+The right to invoke `path_rename` with the file descriptor as the source directory.
+
+___
+
+#### `Const` PATH_RENAME_TARGET
+
+• **PATH_RENAME_TARGET**: *[rights](#modulesrightsmd)* = 131072
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1297
+
+The right to invoke `path_rename` with the file descriptor as the target directory.
+
+___
+
+#### `Const` PATH_UNLINK_FILE
+
+• **PATH_UNLINK_FILE**: *[rights](#modulesrightsmd)* = 67108864
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1333
+
+The right to invoke `path_unlink_file`.
+
+___
+
+#### `Const` POLL_FD_READWRITE
+
+• **POLL_FD_READWRITE**: *[rights](#modulesrightsmd)* = 134217728
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1337
+
+If `rights.FD_READ` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype.FD_READ`. If `rights.FD_WRITE` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype.FD_WRITE`.
+
+___
+
+#### `Const` RIGHT_PATH_SYMLINK
+
+• **RIGHT_PATH_SYMLINK**: *[rights](#modulesrightsmd)* = 16777216
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1325
+
+The right to invoke `path_symlink`.
+
+___
+
+#### `Const` SOCK_SHUTDOWN
+
+• **SOCK_SHUTDOWN**: *[rights](#modulesrightsmd)* = 268435456
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1341
+
+The right to invoke `sock_shutdown`.
+
+
+<a name="modulesroflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [roflags](#modulesroflagsmd)
+
+## Namespace: roflags
+
+Flags returned by `sock_recv`.
+
+### Index
+
+#### Variables
+
+* [DATA_TRUNCATED](#const-data_truncated)
+
+### Variables
+
+#### `Const` DATA_TRUNCATED
+
+• **DATA_TRUNCATED**: *[roflags](#modulesroflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1350
+
+Message data has been truncated.
+
+
+<a name="modulessdflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [sdflags](#modulessdflagsmd)
+
+## Namespace: sdflags
+
+Which channels on a socket to shut down.
+
+### Index
+
+#### Variables
+
+* [RD](#const-rd)
+* [WR](#const-wr)
+
+### Variables
+
+#### `Const` RD
+
+• **RD**: *[sdflags](#modulessdflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1359
+
+Disables further receive operations.
+
+___
+
+#### `Const` WR
+
+• **WR**: *[sdflags](#modulessdflagsmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1363
+
+Disables further send operations.
+
+
+<a name="modulessiflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [siflags](#modulessiflagsmd)
+
+## Namespace: siflags
+
+Flags provided to `sock_send`.
+
+
+<a name="modulessignalmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [signal](#modulessignalmd)
+
+## Namespace: signal
+
+Signal condition.
+
+### Index
+
+#### Variables
+
+* [ABRT](#const-abrt)
+* [ALRM](#const-alrm)
+* [BUS](#const-bus)
+* [CHLD](#const-chld)
+* [CONT](#const-cont)
+* [FPE](#const-fpe)
+* [HUP](#const-hup)
+* [ILL](#const-ill)
+* [INT](#const-int)
+* [KILL](#const-kill)
+* [PIPE](#const-pipe)
+* [POLL](#const-poll)
+* [PROF](#const-prof)
+* [PWR](#const-pwr)
+* [QUIT](#const-quit)
+* [SEGV](#const-segv)
+* [STOP](#const-stop)
+* [SYS](#const-sys)
+* [TERM](#const-term)
+* [TRAP](#const-trap)
+* [TSTP](#const-tstp)
+* [TTIN](#const-ttin)
+* [TTOU](#const-ttou)
+* [URG](#const-urg)
+* [USR1](#const-usr1)
+* [USR2](#const-usr2)
+* [VTALRM](#const-vtalrm)
+* [WINCH](#const-winch)
+* [XCPU](#const-xcpu)
+* [XFSZ](#const-xfsz)
+
+### Variables
+
+#### `Const` ABRT
+
+• **ABRT**: *[signal](#modulessignalmd)* = 6
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1398
+
+Process abort signal.
+
+___
+
+#### `Const` ALRM
+
+• **ALRM**: *[signal](#modulessignalmd)* = 14
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1430
+
+Alarm clock.
+
+___
+
+#### `Const` BUS
+
+• **BUS**: *[signal](#modulessignalmd)* = 7
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1402
+
+Access to an undefined portion of a memory object.
+
+___
+
+#### `Const` CHLD
+
+• **CHLD**: *[signal](#modulessignalmd)* = 16
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1438
+
+Child process terminated, stopped, or continued.
+
+___
+
+#### `Const` CONT
+
+• **CONT**: *[signal](#modulessignalmd)* = 17
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1442
+
+Continue executing, if stopped.
+
+___
+
+#### `Const` FPE
+
+• **FPE**: *[signal](#modulessignalmd)* = 8
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1406
+
+Erroneous arithmetic operation.
+
+___
+
+#### `Const` HUP
+
+• **HUP**: *[signal](#modulessignalmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1378
+
+Hangup.
+
+___
+
+#### `Const` ILL
+
+• **ILL**: *[signal](#modulessignalmd)* = 4
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1390
+
+Illegal instruction.
+
+___
+
+#### `Const` INT
+
+• **INT**: *[signal](#modulessignalmd)* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1382
+
+Terminate interrupt signal.
+
+___
+
+#### `Const` KILL
+
+• **KILL**: *[signal](#modulessignalmd)* = 9
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1410
+
+Kill.
+
+___
+
+#### `Const` PIPE
+
+• **PIPE**: *[signal](#modulessignalmd)* = 13
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1426
+
+Write on a pipe with no one to read it.
+
+___
+
+#### `Const` POLL
+
+• **POLL**: *[signal](#modulessignalmd)* = 28
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1483
+
+___
+
+#### `Const` PROF
+
+• **PROF**: *[signal](#modulessignalmd)* = 26
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1477
+
+___
+
+#### `Const` PWR
+
+• **PWR**: *[signal](#modulessignalmd)* = 29
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1486
+
+___
+
+#### `Const` QUIT
+
+• **QUIT**: *[signal](#modulessignalmd)* = 3
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1386
+
+Terminal quit signal.
+
+___
+
+#### `Const` SEGV
+
+• **SEGV**: *[signal](#modulessignalmd)* = 11
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1418
+
+Invalid memory reference.
+
+___
+
+#### `Const` STOP
+
+• **STOP**: *[signal](#modulessignalmd)* = 18
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1446
+
+Stop executing.
+
+___
+
+#### `Const` SYS
+
+• **SYS**: *[signal](#modulessignalmd)* = 30
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1490
+
+Bad system call.
+
+___
+
+#### `Const` TERM
+
+• **TERM**: *[signal](#modulessignalmd)* = 15
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1434
+
+Termination signal.
+
+___
+
+#### `Const` TRAP
+
+• **TRAP**: *[signal](#modulessignalmd)* = 5
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1394
+
+Trace/breakpoint trap.
+
+___
+
+#### `Const` TSTP
+
+• **TSTP**: *[signal](#modulessignalmd)* = 19
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1450
+
+Terminal stop signal.
+
+___
+
+#### `Const` TTIN
+
+• **TTIN**: *[signal](#modulessignalmd)* = 20
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1454
+
+Background process attempting read.
+
+___
+
+#### `Const` TTOU
+
+• **TTOU**: *[signal](#modulessignalmd)* = 21
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1458
+
+Background process attempting write.
+
+___
+
+#### `Const` URG
+
+• **URG**: *[signal](#modulessignalmd)* = 22
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1462
+
+High bandwidth data is available at a socket.
+
+___
+
+#### `Const` USR1
+
+• **USR1**: *[signal](#modulessignalmd)* = 10
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1414
+
+User-defined signal 1.
+
+___
+
+#### `Const` USR2
+
+• **USR2**: *[signal](#modulessignalmd)* = 12
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1422
+
+User-defined signal 2.
+
+___
+
+#### `Const` VTALRM
+
+• **VTALRM**: *[signal](#modulessignalmd)* = 25
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1474
+
+Virtual timer expired.
+
+___
+
+#### `Const` WINCH
+
+• **WINCH**: *[signal](#modulessignalmd)* = 27
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1480
+
+___
+
+#### `Const` XCPU
+
+• **XCPU**: *[signal](#modulessignalmd)* = 23
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1466
+
+CPU time limit exceeded.
+
+___
+
+#### `Const` XFSZ
+
+• **XFSZ**: *[signal](#modulessignalmd)* = 24
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1470
+
+File size limit exceeded.
+
+
+<a name="modulessubclockflagsmd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [subclockflags](#modulessubclockflagsmd)
+
+## Namespace: subclockflags
+
+Flags determining how to interpret the timestamp provided in `subscription_t::u.clock.timeout.
+
+### Index
+
+#### Variables
+
+* [ABSTIME](#const-abstime)
+
+### Variables
+
+#### `Const` ABSTIME
+
+• **ABSTIME**: *[subclockflags](#modulessubclockflagsmd)* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1499
+
+If set, treat the timestamp provided in `clocksubscription` as an absolute timestamp.
+
+
+<a name="moduleswhencemd"></a>
+
+[assemblyscript](#readmemd) › [Globals](#globalsmd) › [whence](#moduleswhencemd)
+
+## Namespace: whence
+
+The position relative to which to set the offset of the file descriptor.
+
+### Index
+
+#### Variables
+
+* [CUR](#const-cur)
+* [END](#const-end)
+* [SET](#const-set)
+
+### Variables
+
+#### `Const` CUR
+
+• **CUR**: *whence* = 1
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1559
+
+Seek relative to current position.
+
+___
+
+#### `Const` END
+
+• **END**: *whence* = 2
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1563
+
+Seek relative to end-of-file.
+
+___
+
+#### `Const` SET
+
+• **SET**: *whence* = 0
+
+Defined in node_modules/assemblyscript/std/assembly/bindings/wasi_snapshot_preview1.ts:1555
+
+Seek relative to start-of-file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,130 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@textlint/ast-node-types": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-4.3.4.tgz",
+      "integrity": "sha512-Grq+vJuNH7HCa278eFeiqJvowrD+onMCoG2ctLyoN+fXYIQGIr1/8fo8AcIg+VM16Kga+N6Y1UWNOWPd8j1nFg==",
+      "dev": true
+    },
+    "@textlint/markdown-to-ast": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/@textlint/markdown-to-ast/-/markdown-to-ast-6.0.9.tgz",
+      "integrity": "sha512-hfAWBvTeUGh5t5kTn2U3uP3qOSM1BSrxzl1jF3nn0ywfZXpRBZr5yRjXnl4DzIYawCtZOshmRi/tI3/x4TE1jQ==",
+      "dev": true,
+      "requires": {
+        "@textlint/ast-node-types": "^4.0.3",
+        "debug": "^2.1.3",
+        "remark-frontmatter": "^1.2.0",
+        "remark-parse": "^5.0.0",
+        "structured-source": "^3.0.2",
+        "traverse": "^0.6.6",
+        "unified": "^6.1.6"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "anchor-markdown-header": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/anchor-markdown-header/-/anchor-markdown-header-0.5.7.tgz",
+      "integrity": "sha1-BFBj125qH5zTJ6V6ASaqD97Dcac=",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "~6.1.0"
+      }
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
+    },
     "assemblyscript": {
       "version": "0.14.7",
       "resolved": "https://registry.npmjs.org/assemblyscript/-/assemblyscript-0.14.7.tgz",
@@ -14,10 +138,666 @@
         "long": "^4.0.0"
       }
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
     "binaryen": {
       "version": "95.0.0-nightly.20200723",
       "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-95.0.0-nightly.20200723.tgz",
       "integrity": "sha512-IUO89yU4l20ocuf7RvcBj2T1ZGafO0XNcbqTFne9Dbp63FOLafDSuV7U22n0bTbK4H6qqGogTQtQJQbrV054lQ==",
+      "dev": true
+    },
+    "boundary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-1.0.1.tgz",
+      "integrity": "sha1-TWfcJgLAzBbdm85+v4fpSCkPWBI=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "camelcase": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+      "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "dev": true
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "dev": true
+    },
+    "collapse-white-space": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-md": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/concat-md/-/concat-md-0.3.5.tgz",
+      "integrity": "sha512-JVb5rp3JKFqpc6aapqsjgE8k6fWpDJ9YNBNn1Vyi009B1lWc35/cYmT/Rjec7gI4+giC1azkC5RhdHyI2cD89w==",
+      "dev": true,
+      "requires": {
+        "doctoc": "^1.4.0",
+        "front-matter": "^3.1.0",
+        "globby": "^11",
+        "install": "^0.13.0",
+        "lodash.startcase": "^4.4.0",
+        "meow": "^7.0.0",
+        "npm": "^6.14.5",
+        "transform-markdown-links": "^2.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctoc": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/doctoc/-/doctoc-1.4.0.tgz",
+      "integrity": "sha512-8IAq3KdMkxhXCUF+xdZxdJxwuz8N2j25sMgqiu4U4JWluN9tRKMlAalxGASszQjlZaBprdD2YfXpL3VPWUD4eg==",
+      "dev": true,
+      "requires": {
+        "@textlint/markdown-to-ast": "~6.0.9",
+        "anchor-markdown-header": "^0.5.5",
+        "htmlparser2": "~3.9.2",
+        "minimist": "~1.2.0",
+        "underscore": "~1.8.3",
+        "update-section": "^0.3.0"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "emoji-regex": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.3.tgz",
+      "integrity": "sha1-7HmjlpsC0uzytyJUJ5v5m8eoOTI=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dev": true,
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
+    },
+    "front-matter": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-3.2.1.tgz",
+      "integrity": "sha512-YUhgEhbL6tG+Ok3vTGIoSDKqcr47aSDvyhEqIv8B+YuBJFsPnOiArNXTPp2yO07NL+a0L4+2jXlKlKqyVcsRRA==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globby": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+      "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
+      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
+      "dev": true
+    },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "dev": true
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "dev": true,
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-whitespace-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+      "dev": true
+    },
+    "is-word-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
       "dev": true
     },
     "long": {
@@ -25,6 +805,4317 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
+    },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
+    "markdown-escapes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+      "dev": true
+    },
+    "marked": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+      "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==",
+      "dev": true
+    },
+    "meow": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      }
+    },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm": {
+      "version": "6.14.7",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.7.tgz",
+      "integrity": "sha512-swhsdpNpyXg4GbM6LpOQ6qaloQuIKizZ+Zh6JPXJQc59ka49100Js0WvZx594iaKSoFgkFq2s8uXFHS3/Xy2WQ==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.3.5",
+        "abbrev": "~1.1.1",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "^2.0.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.8",
+        "bluebird": "^3.5.5",
+        "byte-size": "^5.0.1",
+        "cacache": "^12.0.3",
+        "call-limit": "^1.1.1",
+        "chownr": "^1.1.4",
+        "ci-info": "^2.0.0",
+        "cli-columns": "^3.1.2",
+        "cli-table3": "^0.5.1",
+        "cmd-shim": "^3.0.3",
+        "columnify": "~1.5.4",
+        "config-chain": "^1.1.12",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "figgy-pudding": "^3.5.1",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.3.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.8.8",
+        "iferr": "^1.0.2",
+        "imurmurhash": "*",
+        "infer-owner": "^1.0.4",
+        "inflight": "~1.0.6",
+        "inherits": "^2.0.4",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "^3.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^4.0.8",
+        "libnpm": "^3.0.1",
+        "libnpmaccess": "^3.0.2",
+        "libnpmhook": "^5.0.3",
+        "libnpmorg": "^1.0.1",
+        "libnpmsearch": "^2.0.2",
+        "libnpmteam": "^1.0.2",
+        "libnpx": "^10.2.4",
+        "lock-verify": "^2.1.0",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^5.1.1",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.5",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^5.1.0",
+        "nopt": "^4.0.3",
+        "normalize-package-data": "^2.5.0",
+        "npm-audit-report": "^1.3.3",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "^3.0.2",
+        "npm-lifecycle": "^3.1.5",
+        "npm-package-arg": "^6.1.1",
+        "npm-packlist": "^1.4.8",
+        "npm-pick-manifest": "^3.0.2",
+        "npm-profile": "^4.0.4",
+        "npm-registry-fetch": "^4.0.5",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "^1.5.1",
+        "osenv": "^0.1.5",
+        "pacote": "^9.5.12",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.8.2",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "^1.0.5",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.1.1",
+        "read-package-tree": "^5.3.1",
+        "readable-stream": "^3.6.0",
+        "readdir-scoped-modules": "^1.1.0",
+        "request": "^2.88.0",
+        "retry": "^0.12.0",
+        "rimraf": "^2.7.1",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.7.1",
+        "sha": "^3.0.0",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^6.0.1",
+        "stringify-package": "^1.0.1",
+        "tar": "^4.4.13",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
+        "uid-number": "0.0.6",
+        "umask": "~1.1.0",
+        "unique-filename": "^1.1.1",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.3.3",
+        "validate-npm-package-license": "^3.0.4",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "^1.3.1",
+        "worker-farm": "^1.7.0",
+        "write-file-atomic": "^2.4.3"
+      },
+      "dependencies": {
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "agent-base": {
+          "version": "4.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        },
+        "agentkeepalive": {
+          "version": "3.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "humanize-ms": "^1.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "ansicolors": {
+          "version": "0.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ansistyles": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "bin-links": {
+          "version": "1.1.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "cmd-shim": "^3.0.0",
+            "gentle-fs": "^2.3.0",
+            "graceful-fs": "^4.1.15",
+            "npm-normalize-package-bin": "^1.0.0",
+            "write-file-atomic": "^2.3.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.5",
+          "bundled": true,
+          "dev": true
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "builtins": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "byline": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "byte-size": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cacache": {
+          "version": "12.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "call-limit": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cidr-regex": {
+          "version": "2.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0"
+          }
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cli-columns": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "cmd-shim": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "color-name": "^1.1.1"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "columnify": {
+          "version": "1.5.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "config-chain": {
+          "version": "1.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "copy-concurrently": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cyclist": {
+          "version": "0.2.2",
+          "bundled": true,
+          "dev": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "clone": "^1.0.2"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "detect-newline": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "dezalgo": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asap": "^2.0.0",
+            "wrappy": "1"
+          }
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "duplexify": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "editor": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "env-paths": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "err-code": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.12.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.8",
+          "bundled": true,
+          "dev": true
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "figgy-pudding": {
+          "version": "3.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "find-npm-prefix": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "flush-write-stream": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.4"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "from2": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "fs-vacuum": {
+          "version": "1.2.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
+          }
+        },
+        "fs-write-stream-atomic": {
+          "version": "1.0.10",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
+          },
+          "dependencies": {
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "genfun": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "gentle-fs": {
+          "version": "2.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.2",
+            "chownr": "^1.1.2",
+            "cmd-shim": "^3.0.3",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "iferr": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ajv": "^5.3.0",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.8.8",
+          "bundled": true,
+          "dev": true
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "bundled": true,
+          "dev": true
+        },
+        "http-proxy-agent": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "4",
+            "debug": "3.1.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "^4.3.0",
+            "debug": "^3.1.0"
+          }
+        },
+        "humanize-ms": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "iferr": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true
+        },
+        "init-package-json": {
+          "version": "1.10.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true
+        },
+        "ip-regex": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "is-ci": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ci-info": "^1.5.0"
+          },
+          "dependencies": {
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "is-cidr": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cidr-regex": "^2.0.10"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-retry-allowed": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "lazy-property": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "libcipm": {
+          "version": "4.0.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "ini": "^1.3.5",
+            "lock-verify": "^2.1.0",
+            "mkdirp": "^0.5.1",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "pacote": "^9.1.0",
+            "read-package-json": "^2.0.13",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.6.0"
+          }
+        },
+        "libnpm": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bin-links": "^1.1.2",
+            "bluebird": "^3.5.3",
+            "find-npm-prefix": "^1.0.2",
+            "libnpmaccess": "^3.0.2",
+            "libnpmconfig": "^1.2.1",
+            "libnpmhook": "^5.0.3",
+            "libnpmorg": "^1.0.1",
+            "libnpmpublish": "^1.1.2",
+            "libnpmsearch": "^2.0.2",
+            "libnpmteam": "^1.0.2",
+            "lock-verify": "^2.0.2",
+            "npm-lifecycle": "^3.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.1.0",
+            "npm-profile": "^4.0.2",
+            "npm-registry-fetch": "^4.0.0",
+            "npmlog": "^4.1.2",
+            "pacote": "^9.5.3",
+            "read-package-json": "^2.0.13",
+            "stringify-package": "^1.0.0"
+          }
+        },
+        "libnpmaccess": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "get-stream": "^4.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmconfig": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "find-up": "^3.0.0",
+            "ini": "^1.3.5"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "libnpmhook": {
+          "version": "5.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmorg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmpublish": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-registry-fetch": "^4.0.0",
+            "semver": "^5.5.1",
+            "ssri": "^6.0.1"
+          }
+        },
+        "libnpmsearch": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpmteam": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^2.0.0",
+            "figgy-pudding": "^3.4.1",
+            "get-stream": "^4.0.0",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "libnpx": {
+          "version": "10.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^14.2.3"
+          }
+        },
+        "lock-verify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-package-arg": "^6.1.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "lockfile": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "lodash._baseindexof": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._baseuniq": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
+          }
+        },
+        "lodash._bindcallback": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._cacheindexof": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._createcache": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash._getnative": "^3.0.0"
+          }
+        },
+        "lodash._createset": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._getnative": {
+          "version": "3.9.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash._root": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.restparam": {
+          "version": "3.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.union": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.uniq": {
+          "version": "4.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.without": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "make-fetch-happen": {
+          "version": "5.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^12.0.0",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
+          }
+        },
+        "meant": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.35.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.19",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.35.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "move-concurrently": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "node-fetch-npm": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "node-gyp": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "env-paths": "^2.2.0",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.2.2",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.1.2",
+            "request": "^2.88.0",
+            "rimraf": "^2.6.3",
+            "semver": "^5.7.1",
+            "tar": "^4.4.12",
+            "which": "^1.3.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
+          }
+        },
+        "npm-audit-report": {
+          "version": "1.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cli-table3": "^0.5.0",
+            "console-control-strings": "^1.1.0"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-cache-filename": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-install-checks": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^2.3.0 || 3.x || 4 || 5"
+          }
+        },
+        "npm-lifecycle": {
+          "version": "3.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.15",
+            "node-gyp": "^5.0.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
+            "uid-number": "0.0.6",
+            "umask": "^1.1.0",
+            "which": "^1.3.1"
+          }
+        },
+        "npm-logical-tree": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "npm-package-arg": {
+          "version": "6.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.7.1",
+            "osenv": "^0.1.5",
+            "semver": "^5.6.0",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "npm-packlist": {
+          "version": "1.4.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-pick-manifest": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1",
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
+          }
+        },
+        "npm-profile": {
+          "version": "4.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.2 || 2",
+            "figgy-pudding": "^3.4.1",
+            "npm-registry-fetch": "^4.0.0"
+          }
+        },
+        "npm-registry-fetch": {
+          "version": "4.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "JSONStream": "^1.3.4",
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^3.4.1",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "npm-package-arg": "^6.1.0",
+            "safe-buffer": "^5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "npm-user-validate": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-keys": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
+        "object.getownpropertydescriptors": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "opener": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pacote": {
+          "version": "9.5.12",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "cacache": "^12.0.2",
+            "chownr": "^1.1.2",
+            "figgy-pudding": "^3.5.1",
+            "get-stream": "^4.1.0",
+            "glob": "^7.1.3",
+            "infer-owner": "^1.0.4",
+            "lru-cache": "^5.1.1",
+            "make-fetch-happen": "^5.0.0",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.5",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-normalize-package-bin": "^1.0.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.12",
+            "npm-pick-manifest": "^3.0.0",
+            "npm-registry-fetch": "^4.0.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.1",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.6.0",
+            "ssri": "^6.0.1",
+            "tar": "^4.4.10",
+            "unique-filename": "^1.1.1",
+            "which": "^1.3.1"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "parallel-transform": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-inflight": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "promise-retry": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
+          },
+          "dependencies": {
+            "retry": {
+              "version": "0.10.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "promzard": {
+          "version": "0.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "read": "1"
+          }
+        },
+        "proto-list": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "protoduck": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "genfun": "^5.0.0"
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "psl": {
+          "version": "1.1.29",
+          "bundled": true,
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "qrcode-terminal": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "query-string": {
+          "version": "6.8.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "split-on-first": "^1.0.0",
+            "strict-uri-encode": "^2.0.0"
+          }
+        },
+        "qw": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "read": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mute-stream": "~0.0.4"
+          }
+        },
+        "read-cmd-shim": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "read-installed": {
+          "version": "4.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
+          }
+        },
+        "read-package-json": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "npm-normalize-package-bin": "^1.0.0"
+          }
+        },
+        "read-package-tree": {
+          "version": "5.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "util-promisify": "^2.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "retry": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-queue": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "aproba": "^1.1.1"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "smart-buffer": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "socks": {
+          "version": "2.3.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ip": "1.1.5",
+            "smart-buffer": "^4.1.0"
+          }
+        },
+        "socks-proxy-agent": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "agent-base": "~4.2.1",
+            "socks": "~2.3.2"
+          },
+          "dependencies": {
+            "agent-base": {
+              "version": "4.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "es6-promisify": "^5.0.0"
+              }
+            }
+          }
+        },
+        "sorted-object": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "sorted-union-stream": {
+          "version": "2.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
+          },
+          "dependencies": {
+            "from2": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "split-on-first": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "sshpk": {
+          "version": "1.14.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "ssri": {
+          "version": "6.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "stream-each": {
+          "version": "1.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "stream-iterate": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "stream-shift": "^1.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strict-uri-encode": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "stringify-package": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
+          },
+          "dependencies": {
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true,
+          "dev": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "tiny-relative-date": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "umask": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unique-filename": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "unique-slug": "^2.0.0"
+          }
+        },
+        "unique-slug": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "util-extend": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "util-promisify": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        },
+        "uuid": {
+          "version": "3.3.3",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtins": "^1.0.3"
+          }
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "defaults": "^1.0.3"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          }
+        },
+        "worker-farm": {
+          "version": "1.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "errno": "~0.1.7"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "dev": true,
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+      "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
+    "remark-frontmatter": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.3.tgz",
+      "integrity": "sha512-fM5eZPBvu2pVNoq3ZPW22q+5Ativ1oLozq2qYt9I2oNyxiUd/tDl0iLLntEVAegpZIslPWg1brhcP1VsaSVUag==",
+      "dev": true,
+      "requires": {
+        "fault": "^1.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "dev": true,
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "state-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
+    "structured-source": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-3.0.2.tgz",
+      "integrity": "sha1-3YAkJeD1PcSm56yjdSkBoczaevU=",
+      "dev": true,
+      "requires": {
+        "boundary": "^1.0.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "transform-markdown-links": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/transform-markdown-links/-/transform-markdown-links-2.0.0.tgz",
+      "integrity": "sha1-t56Sg9RHTLmweYma4JFS1OxGMlo=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true
+    },
+    "typedoc": {
+      "version": "0.17.8",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.8.tgz",
+      "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.0.0",
+        "lodash": "^4.17.15",
+        "lunr": "^2.3.8",
+        "marked": "1.0.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.10.2"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
+      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.8"
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.4.0.tgz",
+      "integrity": "sha512-m4eOwxSzeCbGNFzPDadNQcuMbkbc/45fgXsIP/m4K20i/8zVhCBmvoTxmKUqWYVTYc1BTtvQD5hY/qCueHoLFw==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        }
+      }
+    },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
+      "dev": true,
+      "optional": true
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+      "dev": true
+    },
+    "unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "unified": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+      "dev": true,
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
+      "dev": true
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ==",
+      "dev": true
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "update-section": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/update-section/-/update-section-0.3.3.tgz",
+      "integrity": "sha1-RY8Xgg03gg3GDiC4bZQ5GwASMVg=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.4",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "dev": true,
+      "requires": {
+        "unist-util-stringify-position": "^1.1.1"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs": "npm run docs:clean && npm run docs:typedoc && npm run docs:concat",
     "docs:clean": "rimraf temp-docs",
     "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode file --out temp-docs --tsconfig assembly/tsconfig.json --exclude \"node_modules/**/*\" --readme none assembly",
-    "docs:concat": "concat-md --toc --decrease-title-levels --dir-name-as-title temp-docs > REFERENCE_API_DOCS.md"
+    "docs:concat": "concat-md --decrease-title-levels --dir-name-as-title temp-docs > REFERENCE_API_DOCS.md"
   },
   "devDependencies": {
     "assemblyscript": "^0.14",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "asbuild": "npm run asbuild:optimized",
     "docs": "npm run docs:clean && npm run docs:typedoc && npm run docs:concat",
     "docs:clean": "rimraf temp-docs",
-    "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode file --out temp-docs --tsconfig assembly/tsconfig.json assembly/as-wasi.ts",
+    "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode modules --out temp-docs --tsconfig assembly/tsconfig.json --exclude \"node_modules/**/*\" assembly",
     "docs:concat": "concat-md --toc --decrease-title-levels --dir-name-as-title temp-docs > REFERENCE_API_DOCS.md"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,18 @@
     "asbuild:untouched": "asc assembly/index.ts -b build/untouched.wasm -t build/untouched.wat --use abort=wasi_abort --debug",
     "asbuild:small": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --use abort=wasi_abort -O3z ",
     "asbuild:optimized": "asc assembly/index.ts -b build/optimized.wasm -t build/optimized.wat --use abort=wasi_abort -O3",
-    "asbuild": "npm run asbuild:optimized"
+    "asbuild": "npm run asbuild:optimized",
+    "docs": "npm run docs:clean && npm run docs:typedoc && npm run docs:concat",
+    "docs:clean": "rimraf temp-docs",
+    "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode file --out temp-docs --tsconfig assembly/tsconfig.json assembly/as-wasi.ts",
+    "docs:concat": "concat-md --toc --decrease-title-levels --dir-name-as-title temp-docs > REFERENCE_API_DOCS.md"
   },
   "devDependencies": {
-    "assemblyscript": "^0.14"
+    "assemblyscript": "^0.14",
+    "concat-md": "^0.3.5",
+    "rimraf": "^3.0.2",
+    "typedoc": "^0.17.8",
+    "typedoc-plugin-markdown": "^2.4.0",
+    "typescript": "^3.9.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "asbuild": "npm run asbuild:optimized",
     "docs": "npm run docs:clean && npm run docs:typedoc && npm run docs:concat",
     "docs:clean": "rimraf temp-docs",
-    "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode modules --out temp-docs --tsconfig assembly/tsconfig.json --exclude \"node_modules/**/*\" assembly",
+    "docs:typedoc": "typedoc --plugin typedoc-plugin-markdown --theme markdown --mode file --out temp-docs --tsconfig assembly/tsconfig.json --exclude \"node_modules/**/*\" --readme none assembly",
     "docs:concat": "concat-md --toc --decrease-title-levels --dir-name-as-title temp-docs > REFERENCE_API_DOCS.md"
   },
   "devDependencies": {


### PR DESCRIPTION
This has been on my todo list for a while now haha! :joy: But I wanted to make the project look more appealing for newcomers :smile: 

This just expands on the README with more of the standard README Stuff (License Info, Contributing, badges, etc...). This also adds a way to generate reference documentation, [following this](https://stackoverflow.com/questions/56918621/is-it-possible-to-generate-single-page-doc-html-with-typedoc-for-typescript-proj) but modified for AssemblyScript. Now we can generated docs by running: `npm run docs`. :smile: :tada: 

Thanks! :smile: :+1: 