### PR TITLE
Allow multiple `=` characters in env values

### DIFF
--- a/assembly/as-wasi.ts
+++ b/assembly/as-wasi.ts
@@ -894,10 +894,9 @@ export class Environ {
     }
     for (let i: usize = 0; i < count; i++) {
       let env_ptr = load<usize>(env_ptrs + i * sizeof<usize>());
-      let env_ptr_split = StringUtils.fromCString(env_ptr).split("=", 2);
-      let key = env_ptr_split[0];
-      let value = env_ptr_split[1];
-      this.env.push(new EnvironEntry(key, value));
+      let env = StringUtils.fromCString(env_ptr);
+      let eq = env.indexOf("=");
+      this.env.push(new EnvironEntry(env.substring(0, eq), env.substring(eq + 1)));
     }
   }
 


### PR DESCRIPTION
closes #83 

This commit replaces the use of `split` in the environment variable
parsing with the first index of `=`, in order to properly handle
environment variables that contain `=` in their values.

Specifically, when parsing environment variables with multiple `=`
characters, the first one is used to separate the key from the value,
while the rest are kept as part of the value.
(For example, for the variable `FOO=bar=baz`, the key is `FOO`, and the
value is `bar=baz`).

Note that the fix almost identical with @MaxGraey's suggestion in #83.