### PR TITLE
Add initial GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x, 13.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run asbuild


### PR DESCRIPTION
This commit adds a simple CI step that builds `as-wasi` 
on Linux, using Node 8.x, 10.x, 12.x, 13.x, and 14.x.

If necessary, we could also add macOS and Windows agents 
(although it could increase the build times significantly).

See [this page](https://github.com/radu-matei/as-wasi/actions/runs/305280850) for an example of this action run on my fork.


Edit: I have just noticed the `musedev` check - if the repo already has CI, feel free to close this PR.