### PR TITLE
AssemblyScript >0.20 does not need the wasi import first, remove it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ You can install `as-wasi` in your project by running the following:
 Example usage of the `Console` and `Environ` classes:
 
 ```typescript
-import "wasi";
-
 // Import from the installed as-wasi package
 import { Console, Environ } from "as-wasi/assembly";
 


### PR DESCRIPTION
Hi! Prompted by this StackOverflow [question](https://stackoverflow.com/questions/75362866/server-side-assemblyscript-how-to-read-a-file/75378019#75378019), I tried to use the `as-wasi` module. It seems that there were two problems, one stated in the question, and another one stated in my answer.

AssemblyScript since 0.20 claims to not need the `import "wasi"` as the first line, so it should be removed from examples, or at least stated that recent versions don't require it. It seems to really confuse beginners and may be putting them off of AssemblyScript and `as-wasi`.

The second one was a problem with `wasi_abort`, which now I realize is actually solved on the repo, but not on the npm package, that still has the old version. So maybe a push of the npm package is warranted in this case.

Thank you for the work on this package, and I hope to contribute just at least a little myself.